### PR TITLE
Make `cholesky` work on v1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,11 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.8"
+version = "0.17.9"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
@@ -19,7 +18,8 @@ julia = "1.6"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Base64", "Test", "GenericLinearAlgebra"]
+test = ["Aqua", "Base64", "GenericLinearAlgebra", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.9"
+version = "0.17.8"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -13,8 +13,8 @@ using Base.Broadcast: AbstractArrayStyle, DefaultArrayStyle, Broadcasted
 import Base.Broadcast: BroadcastStyle, broadcasted, materialize, materialize!
 
 using LinearAlgebra: AbstractTriangular, AdjOrTrans, BlasInt, BlasReal, BlasFloat, BlasComplex,
-            checksquare, HermOrSym, chkstride1, QRPackedQ, StructuredMatrixStyle,
-            checknonsingular, ipiv2perm, Givens
+            checksquare, HermOrSym, RealHermSymComplexHerm, chkstride1, QRPackedQ,
+            StructuredMatrixStyle, checknonsingular, ipiv2perm, Givens
 import LinearAlgebra: axpy!, _chol!, rot180, dot, cholcopy, _apply_ipiv_rows!,
             _apply_inverse_ipiv_rows!, diag, eigvals!, eigvals, eigen!, eigen,
             qr, qr!, ldiv!, mul!, lu, lu!, ldlt, ldlt!,

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -1,31 +1,30 @@
 module BandedMatrices
-using Base, FillArrays, ArrayLayouts, LinearAlgebra, SparseArrays, Random
+using Base, FillArrays, ArrayLayouts, LinearAlgebra, SparseArrays
+
+using Base: require_one_based_indexing, reindex, checkbounds, @propagate_inbounds,
+            oneto, promote_op, MultiplicativeInverses, OneTo, ReshapedArray, Slice
+import Base: axes, axes1, getproperty, getindex, setindex!, *, +, -, ==, <, <=, >,
+               >=, /, ^, \, adjoint, transpose, showerror, convert, size, view,
+               unsafe_indices, first, last, size, length, unsafe_length, step, to_indices,
+               to_index, show, fill!, similar, copy, promote_rule, IndexStyle, real, imag,
+               copyto!
+
+using Base.Broadcast: AbstractArrayStyle, DefaultArrayStyle, Broadcasted
+import Base.Broadcast: BroadcastStyle, broadcasted, materialize, materialize!
+
+using LinearAlgebra: AbstractTriangular, AdjOrTrans, BlasInt, BlasReal, BlasFloat, BlasComplex,
+            checksquare, HermOrSym, chkstride1, QRPackedQ, StructuredMatrixStyle,
+            checknonsingular, ipiv2perm, Givens
+import LinearAlgebra: axpy!, _chol!, rot180, dot, cholcopy, _apply_ipiv_rows!,
+            _apply_inverse_ipiv_rows!, diag, eigvals!, eigvals, eigen!, eigen,
+            qr, qr!, ldiv!, mul!, lu, lu!, ldlt, ldlt!,
+            kron, lmul!, rmul!, factorize, logabsdet,
+            svdvals, svdvals!, tril!, triu!, diagzero
+
 using LinearAlgebra.LAPACK
-import Base: axes, axes1, getproperty, iterate, tail
-import LinearAlgebra: BlasInt, BlasReal, BlasFloat, BlasComplex, axpy!,
-                        checksquare, adjoint, transpose, AdjOrTrans, HermOrSym,
-                        _chol!, rot180, dot
-import LinearAlgebra.LAPACK: chkuplo, chktrans
-import LinearAlgebra: cholesky, cholesky!, cholcopy, norm, diag, eigvals!, eigvals, eigen!, eigen,
-            qr, qr!, axpy!, ldiv!, mul!, lu, lu!, ldlt, ldlt!, AbstractTriangular,
-            chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, logabsdet,
-            svdvals, svdvals!, QRPackedQ, checknonsingular, ipiv2perm, tril!,
-            triu!, Givens, diagzero
+using LinearAlgebra.LAPACK: chkuplo, chktrans
+
 import SparseArrays: sparse
-
-import Base: getindex, setindex!, *, +, -, ==, <, <=, >, isassigned,
-                >=, /, ^, \, transpose, showerror, reindex, checkbounds, @propagate_inbounds
-
-import Base: convert, size, view, unsafe_indices,
-                first, last, size, length, unsafe_length, step,
-                to_indices, to_index, show, fill!, promote_op,
-                MultiplicativeInverses, OneTo, ReshapedArray,
-                               similar, copy, convert, promote_rule, rand,
-                            IndexStyle, real, imag, Slice, pointer, unsafe_convert, copyto!,
-                            hcat, vcat, hvcat
-
-import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, DefaultArrayStyle, Broadcasted, broadcasted,
-                        materialize, materialize!
 
 import ArrayLayouts: MemoryLayout, transposelayout, triangulardata,
                     conjlayout, symmetriclayout, symmetricdata,
@@ -59,15 +58,6 @@ export BandedMatrix,
        Ones,
        Eye
 
-
-import Base: require_one_based_indexing
-import LinearAlgebra: _apply_ipiv_rows!
-
-if VERSION < v"1.6-"
-	oneto(n) = OneTo(n)
-else
-	import Base: oneto
-end
 
 include("blas.jl")
 include("lapack.jl")

--- a/src/symbanded/BandedCholesky.jl
+++ b/src/symbanded/BandedCholesky.jl
@@ -96,7 +96,7 @@ ldiv!(A::Cholesky{T,<:AbstractBandedMatrix}, B::StridedVecOrMat{T}) where T<:Bla
 ArrayLayouts._cholesky(::Union{SymmetricLayout{<:AbstractBandedLayout},HermitianLayout{<:AbstractBandedLayout}}, ax, A, ::Val{false}=Val(false); check::Bool = true) =
     cholesky!(cholcopy(A); check = check)
 
-cholcopy(A::Union{HermOrSym{<:Any,<:BandedMatrix}}) =
+cholcopy(A::RealHermSymComplexHerm{<:Any,<:BandedMatrix}) =
     copyto!(similar(A, LinearAlgebra.choltype(A)), A)
 # cholesky(A::Hermitian{T,<:BandedMatrix{T}},
 #     ::Val{false}=Val(false); check::Bool = true) where T = cholesky!(cholcopy(A); check = check)

--- a/src/symbanded/BandedCholesky.jl
+++ b/src/symbanded/BandedCholesky.jl
@@ -93,8 +93,10 @@ ldiv!(A::Cholesky{T,<:AbstractBandedMatrix}, B::StridedVecOrMat{T}) where T<:Bla
 
 
 # For some bizarre reason this isnt in LinearAlgebra
-ArrayLayouts._cholesky(::Union{SymmetricLayout{<:AbstractBandedLayout},HermitianLayout{<:AbstractBandedLayout}}, ax, A, ::Val{false}=Val(false); check::Bool = true) = cholesky!(cholcopy(A); check = check)
+ArrayLayouts._cholesky(::Union{SymmetricLayout{<:AbstractBandedLayout},HermitianLayout{<:AbstractBandedLayout}}, ax, A, ::Val{false}=Val(false); check::Bool = true) =
+    cholesky!(cholcopy(A); check = check)
 
-
+cholcopy(A::Union{HermOrSym{<:Any,<:BandedMatrix}}) =
+    copyto!(similar(A, LinearAlgebra.choltype(A)), A)
 # cholesky(A::Hermitian{T,<:BandedMatrix{T}},
 #     ::Val{false}=Val(false); check::Bool = true) where T = cholesky!(cholcopy(A); check = check)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/47063 "broke" `cholesky` of banded matrices, as it uses 3-arg `similar` for the copy. This fixes it.

It also includes some clean-up about which methods are only used and which ones are overloaded.