### PR TITLE
Turn broken `ldiv` tests to proper tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Aqua = "0.5"
-ArrayLayouts = "0.8"
+ArrayLayouts = "0.8.14"
 FillArrays = "0.13"
 julia = "1.6"
 

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -248,7 +248,7 @@ end
 
         b = rand(T,size(A,1))
         @test Ac\b ≈ Matrix(A)\b
-        @test_broken Ac\b ≈ A\b
+        VERSION >= v"1.9-" && @test Ac\b ≈ A\b
     end
 
     for T in (Float64, BigFloat)
@@ -261,7 +261,7 @@ end
 
         b = rand(T,size(A,1))
         @test Ac\b ≈ Matrix(A)\b
-        @test_broken Ac\b ≈ A\b
+        VERSION >= v"1.9-" && @test Ac\b ≈ A\b
     end
 
     let T = ComplexF64
@@ -274,7 +274,7 @@ end
 
         b = rand(T,size(A,1))
         @test Ac\b ≈ Matrix(A)\b
-        @test_broken Ac\b ≈ A\b
+        VERSION >= v"1.9-" && @test Ac\b ≈ A\b
     end
 
     @testset "UnitRange" begin


### PR DESCRIPTION
Adjusts tests to the generalizations in https://github.com/JuliaLang/julia/pull/47107, which make the tests pass.