### PR TITLE
Use `map!` in broadcasting if sizes match

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -643,7 +643,9 @@ function _banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{AbstractMatrix
     data_d,data_A, data_B = bandeddata(dest), bandeddata(A), bandeddata(B)
 
     if (d_l,d_u) == (A_l,A_u) == (B_l,B_u)
-        data_d .= f.(data_A,data_B)
+        # An inplace map is faster than an inplace broadcast
+        # (checked on Julia v1.8.3 and 1.10 dev)
+        map!(f, data_d, data_A, data_B)
     else
         max_l,max_u = max(A_l,B_l,d_l),max(A_u,B_u,d_u)
         min_l,min_u = min(A_l,B_l,d_l),min(A_u,B_u,d_u)

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -37,6 +37,8 @@ import BandedMatrices: BandedStyle, BandedRows
         @test 1 .+ A isa BandedMatrix
         @test (1 .+ A) == 1 .+ Matrix(A)
 
+        @test A .+ A == 2A
+
         @test 1 .\ A == 1 .\ Matrix(A)
         @test 1 .\ A isa BandedMatrix
         @test bandwidths(1 .\ A) == bandwidths(A)


### PR DESCRIPTION
Using an inplace map instead of inplace broadcasting seems to lead to better performance, for reasons that aren't fully clear to me

On Julia v1.8.3
master:
```julia
julia> using BandedMatrices, BenchmarkTools

julia> B = BandedMatrix(0 => rand(1000), 1=>rand(999), -2=>rand(998));

julia> @btime $B + $B;
  6.585 μs (3 allocations: 31.34 KiB)
```
this PR
```julia
julia> @btime $B + $B;
  4.952 μs (3 allocations: 31.34 KiB)
```

On julia v1.9.0-alpha1
this PR
```julia
julia> @btime $B + $B;
  2.900 μs (3 allocations: 31.34 KiB)
```
while the performance on master is similar.

Edit: this may be due to subpar code generation on my laptop, so I'll check on other systems as well.