### PR TITLE
Force linear indexing while broadcasting over arrays

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -621,10 +621,13 @@ function checkzerobands(dest, f, (A,B)::Tuple{AbstractMatrix,AbstractMatrix})
     end
 end
 
-# Broadcasting uses Cartesian indexing by default, and only vectorizes over the inner index
-# In case the size(data,1) is small, this may not vectorize at all
-# We explicitly use a loop in this case to use linear indices and force vectorization
-# See https://discourse.julialang.org/t/why-is-a-multi-argument-inplace-map-much-faster-in-this-case-than-a-broadcast/91525
+#=
+Broadcasting uses Cartesian indexing by default, and only vectorizes over the innermost index
+In case the size along the first dimension is small, this may not vectorize at all.
+This is often the case with a BandedMatrix, where size(B.data, 1) represents the number of bands
+We explicitly use a loop in this case to use linear indices and force vectorization
+See https://discourse.julialang.org/t/why-is-a-multi-argument-inplace-map-much-faster-in-this-case-than-a-broadcast/91525
+=#
 @inline function _broadcast_linindex!(f, dest::Array, A::Array, B::Array)
     @inbounds @simd for ind in eachindex(A, B, dest)
         dest[ind] = f(A[ind], B[ind])

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -625,13 +625,13 @@ end
 # In case the size(data,1) is small, this may not vectorize at all
 # We explicitly use a loop in this case to use linear indices and force vectorization
 # See https://discourse.julialang.org/t/why-is-a-multi-argument-inplace-map-much-faster-in-this-case-than-a-broadcast/91525
-function _broadcast_linindex!(f, dest::Array, A::Array, B::Array)
+@inline function _broadcast_linindex!(f, dest::Array, A::Array, B::Array)
     @inbounds @simd for ind in eachindex(A, B, dest)
         dest[ind] = f(A[ind], B[ind])
     end
     dest
 end
-_broadcast_linindex!(f, dest, A, B) = dest .= f.(A, B)
+@inline _broadcast_linindex!(f, dest, A, B) = dest .= f.(A, B)
 
 function _banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{AbstractMatrix,AbstractMatrix}, ::BandedColumns, ::Tuple{<:BandedColumns,<:BandedColumns})
     z = f(zero(eltype(A)), zero(eltype(B)))


### PR DESCRIPTION
A second attempt at https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/pull/284, now that I understand the issue better. I don't fully understand the objection to `map!`, so I'm open to discussion. Using an explicit loop --- as in this PR --- seems to be the fastest on my laptop on Julia v1.8.4. This difference arises because broadcasting uses Cartesian indexing, which doesn't lead to effective vectorization for a `BandedMatrix` if the number of bands is small. Using an explicit loop (or using `map!`), we force the use of linear indexing, which leads to better performance.

On master
```julia
julia> B = BandedMatrix(0 => rand(1000), 1=>rand(999), -2=>rand(998));

julia> @btime $B + $B;
  5.170 μs (3 allocations: 31.34 KiB)
```
Using `map!` (as in #284)
```julia
julia> @btime $B + $B;
  3.120 μs (3 allocations: 31.34 KiB)
```
This PR
```julia
julia> @btime $B + $B;
  1.620 μs (3 allocations: 31.34 KiB)
```
On Julia v1.9.0-beta2, the performance using `map!` is identical to that using an explicit loop.