### PR TITLE
Update `BandSlice` docstring and fix docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,15 +11,17 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Aqua = "0.5"
 ArrayLayouts = "0.8.14"
+Documenter = "0.27"
 FillArrays = "0.13"
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Base64", "GenericLinearAlgebra", "Random", "Test"]
+test = ["Aqua", "Base64", "Documenter", "GenericLinearAlgebra", "Random", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
+
+[compat]
+Documenter = "0.27"
+LazyArrays = "0.22"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,6 @@ makedocs(;
     repo = "https://github.com/JuliaMatrices/BandedMatrices.jl/blob/{commit}{path}#L{line}",
     sitename = "BandedMatrices.jl",
     authors = "Sheehan Olver, Mikael Slevinsky, and contributors.",
-    assets = String[],
 )
 
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,10 +8,6 @@ BandedMatrix
 ```
 
 ```@docs
-bones
-```
-
-```@docs
 brand
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,11 @@ using Aqua
     Aqua.test_all(BandedMatrices, ambiguities=false)
 end
 
+using Documenter
+@testset "doctests" begin
+    doctest(BandedMatrices)
+end
+
 include("test_banded.jl")
 include("test_subarray.jl")
 include("test_linalg.jl")


### PR DESCRIPTION
Change `AbstractUnitRange` → `StepRange` in the docstring of `BandSlice`, since `diagind` returns a step range. Also, fix some outdated docstring errors and add compat bounds to the documentation project.