### PR TITLE
Add `isbanded` fallback

### DIFF
--- a/src/generic/AbstractBandedMatrix.jl
+++ b/src/generic/AbstractBandedMatrix.jl
@@ -97,6 +97,7 @@ returns true if a matrix implements the banded interface.
 """
 isbanded(A) = isbanded(MemoryLayout(A), A)
 isbanded(::AbstractBandedLayout, A) = true
+isbanded(@nospecialize(::Any), @nospecialize(::Any)) = false
 
 # override bandwidth(A,k) for each AbstractBandedMatrix
 # override inbands_getindex(A,k,j)

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -120,6 +120,10 @@ LinearAlgebra.fill!(A::PseudoBandedMatrix, v) = fill!(A.data,v)
         @test BandedMatrix(U) == U
     end
 
+    @testset "!Array" begin
+        @test !BandedMatrices.isbanded(zeros(0,0))
+    end
+
     A = PseudoBandedMatrix(rand(5, 4), 2, 2)
     B = rand(5, 4)
     C = copy(B)


### PR DESCRIPTION
It's useful to know that some matrix types don't implement the `BandedMatrix` interface, and this does not need to error like it does at present.

After this PR:
```julia
julia> isbanded(rand(3,3))
false
```
This errors on master.