### PR TITLE
Check `isbanded` in conversions

### DIFF
--- a/src/interfaceimpl.jl
+++ b/src/interfaceimpl.jl
@@ -26,7 +26,9 @@ isbanded(::Diagonal) = true
 bandwidths(::Diagonal) = (0,0)
 inbands_getindex(D::Diagonal, k::Integer, j::Integer) = D.diag[k]
 inbands_setindex!(D::Diagonal, v, k::Integer, j::Integer) = (D.diag[k] = v)
-bandeddata(D::Diagonal) = permutedims(D.diag)
+function bandeddata(D::Union{Diagonal, Transpose{<:Any, <:Diagonal}, Adjoint{<:Any,<:Diagonal}})
+    permutedims(diagonaldata(D))
+end
 
 # treat subinds as banded
 sublayout(::DiagonalLayout{L}, inds::Type) where L = sublayout(bandedcolumns(L()), inds)

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -61,6 +61,19 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
         @test BandedMatrix{Int64, typeof(matrix)}(matrix, (1, 1)) isa BandedMatrix{Int64, typeof(matrix)}
         @test BandedMatrix{Int64, typeof(matrix)}(matrix, (1, 1)).data isa typeof(matrix)
         @test_throws UndefRefError BandedMatrix{Vector{Float64}}(undef, (5,5), (1,1))[1,1]
+
+        @testset "Construction from Diagonal" begin
+            D = Diagonal(1:4)
+            B1 = BandedMatrix(D)
+            @test B1 isa BandedMatrix{Int}
+            @test B1 == D
+            B2 = BandedMatrix{Float64}(D)
+            @test B2 isa BandedMatrix{Float64}
+            @test B2 == D
+            B3 = BandedMatrix{Float32,Matrix{Float32}}(D)
+            @test B3 isa BandedMatrix{Float32,Matrix{Float32}}
+            @test B3 == D
+        end
     end
 
     @testset "BandedMatrix arithmetic" begin

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -1,6 +1,6 @@
 using BandedMatrices, LinearAlgebra, ArrayLayouts, FillArrays, Test, Base64
 import BandedMatrices: banded_mul!, isbanded, AbstractBandedLayout, BandedStyle,
-                        rowsupport, colsupport, _BandedMatrix, BandedColumns
+                        rowsupport, colsupport, _BandedMatrix, BandedColumns, bandeddata
 import ArrayLayouts: OnesLayout, UnknownLayout
 
 struct PseudoBandedMatrix{T} <: AbstractMatrix{T}
@@ -69,6 +69,8 @@ LinearAlgebra.fill!(A::PseudoBandedMatrix, v) = fill!(A.data,v)
         @test A[1,1] == 2
         @test A[1,2] == 0
         @test BandedMatrices.@inbands(A[1,2]) == 2
+
+        @test bandeddata(A) == bandeddata(Adjoint(A)) == bandeddata(Transpose(A)) == diag(A)'
 
         @test MemoryLayout(view(A, 1:3,2:4)) isa BandedColumns{DenseColumnMajor}
         @test MemoryLayout(view(A, [1,2,3],2:4)) isa UnknownLayout


### PR DESCRIPTION
While converting from an `AbstractMatrix` to a `BandedMatrix`, we may use a faster path if the argument is banded and has a `BandedColumns{DenseColumnMajor}()` memory layout .
On master
```julia
julia> D = Diagonal(rand(1000));

julia> @btime convert(BandedMatrix, $D);
  4.521 μs (4 allocations: 8.11 KiB)

julia> @btime BandedMatrix{Float32}($D);
  4.588 μs (2 allocations: 4.11 KiB)

julia> @btime BandedMatrix($D);
  2.396 μs (2 allocations: 7.98 KiB)
```
This PR
```julia
julia> @btime convert(BandedMatrix, $D);
  759.925 ns (6 allocations: 8.20 KiB)

julia> @btime BandedMatrix{Float32}($D);
  564.160 ns (4 allocations: 4.20 KiB)

julia> @btime BandedMatrix($D);
  641.483 ns (4 allocations: 8.06 KiB)
```
With some refactoring, all of these could become equally performant.

TBH I'm a bit surprised that this is necessary at all, since I would have thought that banded broadcast already handles this. Presumably, much of the gain comes from linear indexing and vectorization.