### PR TITLE
Precompile instructions for basic algebra operations

### DIFF
--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -95,4 +95,14 @@ include("interfaceimpl.jl")
 
 # _precompile_()
 
+# precompile instructions
+let B = BandedMatrix(0=>zeros(0)), v = zeros(size(B,2))
+    BT = typeof(B)
+    vT = typeof(v)
+    @assert precompile(+, (BT, BT))
+    @assert precompile(-, (BT,))
+    @assert precompile(-, (BT, BT))
+    @assert precompile(*, (BT, vT))
+end
+
 end #module

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -829,7 +829,7 @@ BroadcastStyle(::Type{<:BandedMatrix{<:Any,Dat}}) where Dat = bandedbroadcaststy
 # precompile instructions
 let B = BandedMatrix(0=>zeros(0))
     BT = typeof(B)
-    precompile(+, (BT, BT))
-    precompile(-, (BT,))
-    precompile(-, (BT, BT))
+    @assert precompile(+, (BT, BT))
+    @assert precompile(-, (BT,))
+    @assert precompile(-, (BT, BT))
 end

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -825,11 +825,3 @@ end
 
 bandedbroadcaststyle(_) = BandedStyle()
 BroadcastStyle(::Type{<:BandedMatrix{<:Any,Dat}}) where Dat = bandedbroadcaststyle(BroadcastStyle(Dat))
-
-# precompile instructions
-let B = BandedMatrix(0=>zeros(0))
-    BT = typeof(B)
-    @assert precompile(+, (BT, BT))
-    @assert precompile(-, (BT,))
-    @assert precompile(-, (BT, BT))
-end

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -825,3 +825,11 @@ end
 
 bandedbroadcaststyle(_) = BandedStyle()
 BroadcastStyle(::Type{<:BandedMatrix{<:Any,Dat}}) where Dat = bandedbroadcaststyle(BroadcastStyle(Dat))
+
+# precompile instructions
+let B = BandedMatrix(0=>zeros(0))
+    BT = typeof(B)
+    precompile(+, (BT, BT))
+    precompile(-, (BT,))
+    precompile(-, (BT, BT))
+end


### PR DESCRIPTION
A simpler alternative to https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/pull/283, without the need for extra packages, and one that seems to work almost as well for many cases.

After this, the time to first execution practically disappears for addition and subtraction for the common use case where the parent is a `Matrix{Float64}`
```julia
julia> using BandedMatrices

julia> B = BandedMatrix(0=>ones(1000));

julia> @time B + B;
  0.000110 seconds (63 allocations: 11.375 KiB)
```

Some others aren't completely eliminated, but considerably improved:
```julia
julia> v = ones(size(B,2));

julia> @time @eval B * v;
  0.009193 seconds (8.87 k allocations: 556.567 KiB)
```