### PR TITLE
Avoid recursion in `_banded_muladd!` for vectors

### DIFF
--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -51,11 +51,11 @@ function _banded_muladd!(α::T, A, x::AbstractVector, β, y) where T
     l, u = bandwidths(A)
     if -l > u # no bands
         _fill_lmul!(β, y)
-    elseif l < 0 # with u >= -l > 0, that is all bands lie above the diagonal
+    elseif l < 0 # with u >= -l > 0, that is, all bands lie above the diagonal
         # E.g. (l,u) = (-1,2)
         # set lview = 0 and uview = u + l >= 0
         _banded_gbmv!('N', α, view(A, :, 1-l:n), view(x, 1-l:n), β, y)
-    elseif u < 0 # with -l <= u < 0, that is all bands lie below the diagnoal.
+    elseif u < 0 # with -l <= u < 0, that is, all bands lie below the diagnoal.
         # E.g. (l,u) = (2,-1)
         # set lview = l + u >= 0 and uview = 0
         y[1:-u] .= zero(T)

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -26,17 +26,16 @@ banded_gbmv!(tA, α, A, x, β, y) =
 
 
 @inline function _banded_gbmv!(tA, α, A, x, β, y)
-    #= Some BLAS implementations throw warnings if the
-    arrays have a zero-sized axis, so we handle
+    #= Some BLAS implementations throw warnings
+    with zero-sized arrays, so we handle
     these cases separately.
     =#
     length(y) == 0 && return y
     if length(x) == 0
         _fill_lmul!(β, y)
-    elseif x ≡ y
-        banded_gbmv!(tA, α, A, copy(x), β, y)
     else
-        banded_gbmv!(tA, α, A, x, β, y)
+        xc = x ≡ y ? copy(x) : x
+        banded_gbmv!(tA, α, A, xc, β, y)
     end
     return y
 end

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -26,11 +26,19 @@ banded_gbmv!(tA, α, A, x, β, y) =
 
 
 @inline function _banded_gbmv!(tA, α, A, x, β, y)
-    if x ≡ y
+    #= Some BLAS implementations throw warnings if the
+    arrays have a zero-sized axis, so we handle
+    these cases separately.
+    =#
+    length(y) == 0 && return y
+    if length(x) == 0
+        _fill_lmul!(β, y)
+    elseif x ≡ y
         banded_gbmv!(tA, α, A, copy(x), β, y)
     else
         banded_gbmv!(tA, α, A, x, β, y)
     end
+    return y
 end
 
 

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -111,6 +111,15 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
             @test A*v ≈ Matrix(A)*v
             @test A'*w ≈ Matrix(A)'*w
         end
+
+        @testset "empty" begin
+            let B=BandedMatrix((0=>ones(0),), (10,0)), v = ones(size(B,2))
+                @test B * v == zeros(size(B,1))
+            end
+            let B=BandedMatrix((0=>ones(0),), (0,10)), v = ones(size(B,2))
+                @test B * v == zeros(size(B,1))
+            end
+        end
     end
 
     @testset "Banded * Dense" begin


### PR DESCRIPTION
We may avoid recursion in `_banded_muladd!` and directly call `_banded_gbmv!`instead. This makes type-inference easier, and reduces TTFX. 
On master
```julia
julia> B = BandedMatrix(0=>ones(1000));

julia> v = zeros(size(B,2));

julia> @time B * v;
  1.007807 seconds (2.95 M allocations: 193.016 MiB, 7.89% gc time, 182.64% compilation time)
```
This PR
```julia
julia> @time B * v;
  0.294613 seconds (647.92 k allocations: 42.859 MiB, 5.88% gc time, 151.79% compilation time)
```
Tests for `BlockBandedMatrices`, `ApproxFunBase`, `ApproxFunOrthogonalPolynomials` and `ApproxFun` pass locally for me with this PR. This also resolves the issue with precompiling `B * v` in https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/pull/283#issuecomment-1379893550