### PR TITLE
Shift limits from row to col in rowvec/colvec banded_broadcast

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.17.10"
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Aqua = "0.5"
 ArrayLayouts = "0.8.14"
 FillArrays = "0.13"
+MacroTools = "0.5"
 julia = "1.6"
 
 [extras]

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -38,6 +38,8 @@ import ArrayLayouts: MemoryLayout, transposelayout, triangulardata,
 
 import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_value
 
+using MacroTools
+
 const libblas = Base.libblas_name
 const liblapack = Base.liblapack_name
 

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -855,7 +855,7 @@ function checkzerobands(dest, f, (A,B)::Tuple{AbstractMatrix,AbstractMatrix})
     B_l, B_u = bandwidths(B)
     l, u = max(A_l,B_l), max(A_u,B_u)
 
-    @switchlimits for j = 1:n
+    for j = 1:n
         for k = max(1,j-u) : min(j-d_u-1,m)
             iszero(f(A[k,j], B[k,j])) || throw(BandError(dest,b))
         end

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -516,29 +516,74 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     d_l, d_u = bandwidths(dest)
     A_l, A_u = bandwidths(A)
     B_l, B_u = _broadcast_bandwidths((m-1,n-1),B)
+    @assert B_l == m-1
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == A_l == l && d_u == A_u == u
+        if B_u >= u
+            if B_l >= l
+                for j=1:n
+                    for k = max(1,j-u):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                end
+            else
+                for j=1:n
+                    for k = max(1,j-u):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                    for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                end
+            end
+        else
+            if B_l >= l
+                for j=1:n
+                    for k = max(1,j-u):min(j-B_u-1,j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                    for k = max(1,j-min(u,B_u)):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                end
+            else
+                for j=1:n
+                    for k = max(1,j-u):min(j-B_u-1,j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                    for k = max(1,j-min(u,B_u)):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                    for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                end
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[j]), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[j]), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=1:n
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[j]), k, j)
+            end
+            for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+            end
+            for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[j]), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -822,7 +822,7 @@ function _banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{AbstractMatrix
     B_l, B_u = bandwidths(B)
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    @switchlimits for j=1:n
+    for j=1:n
         for k = max(1,j-d_u):min(j-u-1,j+d_l,m)
             inbands_setindex!(dest, z, k, j)
         end

--- a/src/interfaceimpl.jl
+++ b/src/interfaceimpl.jl
@@ -24,8 +24,8 @@ inbands_getindex(::Eye{T}, k::Integer, j::Integer) where T = one(T)
 
 isbanded(::Diagonal) = true
 bandwidths(::Diagonal) = (0,0)
-inbands_getindex(D::Diagonal, k::Integer, j::Integer) = D.diag[k]
-inbands_setindex!(D::Diagonal, v, k::Integer, j::Integer) = (D.diag[k] = v)
+Base.@propagate_inbounds inbands_getindex(D::Diagonal, k::Integer, j::Integer) = D.diag[k]
+Base.@propagate_inbounds inbands_setindex!(D::Diagonal, v, k::Integer, j::Integer) = (D.diag[k] = v)
 bandeddata(D::Diagonal) = permutedims(D.diag)
 
 # treat subinds as banded


### PR DESCRIPTION
The various banded broadcast methods have loops of the form
```julia
for j=1:n
        for k = max(1,j-d_u):min(j-u-1,m)
            inbands_setindex!(dest, z, k, j)
        end
end
```
This involves `max` and `min` calls for each `j`, which adds an `O(n)` overhead. It seems this isn't negligible, and shifting the limits from `k` to `j` improves performance by a significant extent. Doing this manually is tedious, error-prone, and hard to maintain, so I've written a macro to do this.

With arrays
```julia
julia> A = BandedMatrix(0=>Float64[1:3000;]); D = Diagonal(A);

julia> A2 = brand(3000, 3000, (200,200)); D2 = Diagonal(A2);
```
Runtimes:
| Operation | master | PR |
| --- | :-: |  :-: |
|`A * D` | 54.493 μs | 13.244 μs |
|`D * A` | 49.778 μs | 45.225 μs |
|`A2 * D2` | 53.917 μs | 12.976 μs |
|`D2 * A2` | 49.282 μs | 44.779 μs |

This only really improves things if `A` also has few bands, so we may add a special path for that. If the number of bands is high, this will likely make things worse due to cache misses. I see the times being roughly equal for tridiagonal matrices. Perhaps we should only use this for diagonal matrices, in which case this is a clear improvement.

However, in the diagonal case, a dot product is much more performant, so this is perhaps unnecessary.

I've added [MacroTools](https://github.com/FluxML/MacroTools.jl) as a dependency to make life simpler. This adds 15.0 ms to the package load time, which is negligible compared to the other dependencies. This should also be maintained, as it's a part of the FluxML organization.