### PR TITLE
Split loops into cases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,18 @@ version = "0.17.10"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Aqua = "0.5"
 ArrayLayouts = "0.8.14"
+Combinatorics = "1"
 FillArrays = "0.13"
+MacroTools = "0.5"
 julia = "1.6"
 
 [extras]

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -41,6 +41,9 @@ import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_valu
 const libblas = Base.libblas_name
 const liblapack = Base.liblapack_name
 
+using MacroTools
+using Combinatorics: combinations
+
 export BandedMatrix,
        bandrange,
        brand,

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -127,19 +127,19 @@ function _banded_broadcast!(dest::AbstractMatrix, f, src::AbstractMatrix{T}, _1,
         return dest
     elseif -d_u > -s_u-1
         if max(-s_u, -d_u) > min(s_l, d_l)
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j+s_l+1):min(j+d_l,m)
                     inbands_setindex!(dest, z, k, j)
                 end
             end
         elseif s_l+1 > d_l
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-s_u,j-d_u):min(j+s_l,j+d_l,m)
                     inbands_setindex!(dest, f(inbands_getindex(src, k, j)), k, j)
                 end
             end
         else
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-s_u,j-d_u):min(j+s_l,j+d_l,m)
                     inbands_setindex!(dest, f(inbands_getindex(src, k, j)), k, j)
                 end
@@ -150,19 +150,19 @@ function _banded_broadcast!(dest::AbstractMatrix, f, src::AbstractMatrix{T}, _1,
         end
     elseif max(-s_u, -d_u) > min(s_l, d_l)
         if -d_u > -s_u-1
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j+s_l+1):min(j+d_l,m)
                     inbands_setindex!(dest, z, k, j)
                 end
             end
         elseif s_l+1 > d_l
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-d_u):min(j-s_u-1,m)
                     inbands_setindex!(dest, z, k, j)
                 end
             end
         else
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-d_u):min(j-s_u-1,m)
                     inbands_setindex!(dest, z, k, j)
                 end
@@ -173,19 +173,19 @@ function _banded_broadcast!(dest::AbstractMatrix, f, src::AbstractMatrix{T}, _1,
         end
     elseif s_l+1 > d_l
         if -d_u > -s_u-1
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-s_u,j-d_u):min(j+s_l,j+d_l,m)
                     inbands_setindex!(dest, f(inbands_getindex(src, k, j)), k, j)
                 end
             end
         elseif max(-s_u, -d_u) > min(s_l, d_l)
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-d_u):min(j-s_u-1,m)
                     inbands_setindex!(dest, z, k, j)
                 end
             end
         else
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-d_u):min(j-s_u-1,m)
                     inbands_setindex!(dest, z, k, j)
                 end
@@ -195,7 +195,7 @@ function _banded_broadcast!(dest::AbstractMatrix, f, src::AbstractMatrix{T}, _1,
             end
         end
     else
-        for j=1:n
+        for j=rowsupport(dest)
             for k = max(1,j-d_u):min(j-s_u-1,m)
                 inbands_setindex!(dest, z, k, j)
             end
@@ -759,19 +759,19 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
         if -u > min(-B_u-1, l) && -min(u,B_u) > l
             return dest
         elseif -u > min(-B_u-1, l)
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-min(u,B_u)):min(j+l,m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
                 end
             end
         elseif -min(u,B_u) > l
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-u):min(j-B_u-1,j+l,m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
                 end
             end
         else
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-u):min(j-B_u-1,j+l,m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
                 end
@@ -781,7 +781,7 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
             end
         end
     else
-        for j=1:n
+        for j=rowsupport(dest)
             for k = max(1,j-d_u):min(j-u-1,m)
                 inbands_setindex!(dest, z, k, j)
             end

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -402,9 +402,6 @@ function _left_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
 
     if d_l == B_l == l && d_u == B_u == u
         for j=1:n
-            for k = max(1,j-u):min(j-A_u-1,j+l,m)
-                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-            end
             for k = max(1,j-min(A_u,u)):min(j+min(A_l,l),m)
                 inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
             end
@@ -417,13 +414,10 @@ function _left_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
             for k = max(1,j-d_u):min(j-u-1,m)
                 inbands_setindex!(dest, z, k, j)
             end
-            for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
+            for k = max(1,j-d_u):min(j-B_u-1,j+d_l,m)
                 inbands_setindex!(dest, f(A[k], zero(V)), k, j)
             end
-            for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-            end
-            for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
+            for k = max(1,j-B_u):min(j+min(A_l,B_l),m)
                 inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
             end
             for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
@@ -453,31 +447,41 @@ function _right_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     d_l, d_u = bandwidths(dest)
     A_l, A_u = bandwidths(A)
     B_l, B_u = _broadcast_bandwidths((m-1,n-1),B)
+    @assert B_u == n-1
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == A_l == l && d_u == A_u == u
+        for j=1:n
+            for k = max(1,j-min(u,n-1)):min(j+min(l,B_l),m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
+            end
+            for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[k]), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[k]), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=1:n
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[k]), k, j)
+            end
+            for k = max(1,j-A_u):min(j+min(A_l,B_l),m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
+            end
+            for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[k]), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
+
     dest
 end
 
@@ -491,30 +495,39 @@ function _left_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
 
     d_l, d_u = bandwidths(dest)
     A_l, A_u = _broadcast_bandwidths((m-1,n-1),A)
+    @assert A_l == m-1
     B_l, B_u = bandwidths(B)
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == B_l == l && d_u == B_u == u
+        for j=1:n
+            for k = max(1,j-u):min(j-A_u-1,j+l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-min(A_u,u)):min(j+l,m)
+                inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(A[j], zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(A[j], zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=1:n
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(A[j], zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-min(A_u,B_u)):min(j+B_l,m)
+                inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-d_u,j+B_l+1):min(j+d_l,m)
+                inbands_setindex!(dest, f(A[j], zero(V)), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest
@@ -539,11 +552,8 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
             for k = max(1,j-u):min(j-B_u-1,j+l,m)
                 inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
             end
-            for k = max(1,j-min(u,B_u)):min(j+min(l,B_l),m)
+            for k = max(1,j-min(u,B_u)):min(j+l,m)
                 inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
-            end
-            for k = max(1,j-u,j+l+1):min(j+B_l,j+l,m)
-                inbands_setindex!(dest, f(zero(T), B[j]), k, j)
             end
         end
     else
@@ -557,13 +567,10 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
             for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
                 inbands_setindex!(dest, f(zero(T), B[j]), k, j)
             end
-            for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
+            for k = max(1,j-min(A_u,B_u)):min(j+A_l,m)
                 inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
             end
-            for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-            end
-            for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
+            for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l)
                 inbands_setindex!(dest, f(zero(T), B[j]), k, j)
             end
             for k = max(1,j+l+1):min(j+d_l,m)

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -123,7 +123,9 @@ function _banded_broadcast!(dest::AbstractMatrix, f, src::AbstractMatrix{T}, _1,
         end
     end
 
-    if -d_u > -s_u-1 && !(max(-s_u, -d_u) > min(s_l, d_l) && s_l+1 > d_l)
+    if -d_u > -s_u-1 && max(-s_u, -d_u) > min(s_l, d_l) && s_l+1 > d_l
+        return dest
+    elseif -d_u > -s_u-1 && !(max(-s_u, -d_u) > min(s_l, d_l) && s_l+1 > d_l)
         if max(-s_u, -d_u) > min(s_l, d_l)
             for j=1:n
                 for k = max(1,j+s_l+1):min(j+d_l,m)
@@ -486,7 +488,9 @@ function _left_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == B_l == l && d_u == B_u == u
-        if max(-A_u,-u) > min(A_l,l)
+        if max(-A_u,-u) > min(A_l,l) && max(-u,A_l+1) > l
+            return dest
+        elseif max(-A_u,-u) > min(A_l,l)
             for j=1:n
                 for k = max(1,j-u,j+A_l+1):min(j+l,m)
                     inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
@@ -550,7 +554,9 @@ function _right_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == A_l == l && d_u == A_u == u
-        if -min(u,n-1) > min(l,B_l)
+        if -min(u,n-1) > min(l,B_l) && max(-u,B_l+1) > l
+            return dest
+        elseif -min(u,n-1) > min(l,B_l)
             for j=1:n
                 for k = max(1,j-u,j+B_l+1):min(j+l,m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
@@ -613,7 +619,9 @@ function _left_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == B_l == l && d_u == B_u == u
-        if -u > min(-A_u-1,l)
+        if -u > min(-A_u-1,l) && -min(A_u,u) > l
+            return dest
+        elseif -u > min(-A_u-1,l)
             for j=1:n
                 for k = max(1,j-min(A_u,u)):min(j+l,m)
                     inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
@@ -675,7 +683,9 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == A_l == l && d_u == A_u == u
-        if -u > min(-B_u-1, l)
+        if -u > min(-B_u-1, l) && -min(u,B_u) > l
+            return dest
+        elseif -u > min(-B_u-1, l)
             for j=1:n
                 for k = max(1,j-min(u,B_u)):min(j+l,m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -516,29 +516,74 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     d_l, d_u = bandwidths(dest)
     A_l, A_u = bandwidths(A)
     B_l, B_u = _broadcast_bandwidths((m-1,n-1),B)
+    @assert B_l == m-1
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == A_l == l && d_u == A_u == u
+        if B_u >= u
+            if B_l >= l
+                for j=1:n
+                    for k = max(1,j-u):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                end
+            else
+                for j=1:n
+                    for k = max(1,j-u):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                    for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                end
+            end
+        else
+            if B_l >= l
+                for j=1:n
+                    for k = max(1,j-u):min(j-B_u-1,j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                    for k = max(1,j-min(u,B_u)):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                end
+            else
+                for j=1:n
+                    for k = max(1,j-u):min(j-B_u-1,j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                    for k = max(1,j-min(u,B_u)):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                    end
+                    for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                        inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                    end
+                end
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[j]), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[j]), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=1:n
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[j]), k, j)
+            end
+            for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+            end
+            for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[j]), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -436,15 +436,88 @@ function _banded_broadcast!(dest::AbstractMatrix, f, (x,src)::Tuple{Number,Abstr
     s_l, s_u = bandwidths(src)
     (d_l ≥ min(s_l,m-1) && d_u ≥ min(s_u,n-1)) || throw(BandError(dest))
 
-    for j = rowsupport(dest)
-        for k = max(1,j-d_u):min(j-s_u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if -d_u > -s_u-1 && -s_u > s_l && s_l+1 > d_l
+        return dest
+    elseif -d_u > -s_u-1
+        if -s_u > s_l
+            for j = rowsupport(dest)
+                for k = max(1,j+s_l+1):min(j+d_l,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+            end
+        elseif s_l+1 > d_l
+            for j = rowsupport(dest)
+                for k = max(1,j-s_u):min(j+s_l,m)
+                    inbands_setindex!(dest, f(x, inbands_getindex(src, k, j)), k, j)
+                end
+            end
+        else
+            for j = rowsupport(dest)
+                for k = max(1,j-s_u):min(j+s_l,m)
+                    inbands_setindex!(dest, f(x, inbands_getindex(src, k, j)), k, j)
+                end
+                for k = max(1,j+s_l+1):min(j+d_l,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+            end
         end
-        for k = max(1,j-s_u):min(j+s_l,m)
-            inbands_setindex!(dest, f(x, inbands_getindex(src, k, j)), k, j)
+    elseif -s_u > s_l
+        if -d_u > -s_u-1
+            for j = rowsupport(dest)
+                for k = max(1,j+s_l+1):min(j+d_l,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+            end
+        elseif s_l+1 > d_l
+            for j = rowsupport(dest)
+                for k = max(1,j-d_u):min(j-s_u-1,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+            end
+        else
+            for j = rowsupport(dest)
+                for k = max(1,j-d_u):min(j-s_u-1,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+                for k = max(1,j+s_l+1):min(j+d_l,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+            end
         end
-        for k = max(1,j+s_l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    elseif s_l+1 > d_l
+        if -d_u > -s_u-1
+            for j = rowsupport(dest)
+                for k = max(1,j-s_u):min(j+s_l,m)
+                    inbands_setindex!(dest, f(x, inbands_getindex(src, k, j)), k, j)
+                end
+            end
+        elseif -s_u > s_l
+            for j = rowsupport(dest)
+                for k = max(1,j-d_u):min(j-s_u-1,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+            end
+        else
+            for j = rowsupport(dest)
+                for k = max(1,j-d_u):min(j-s_u-1,m)
+                    inbands_setindex!(dest, z, k, j)
+                end
+                for k = max(1,j-s_u):min(j+s_l,m)
+                    inbands_setindex!(dest, f(x, inbands_getindex(src, k, j)), k, j)
+                end
+            end
+        end
+    else
+        for j = rowsupport(dest)
+            for k = max(1,j-d_u):min(j-s_u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-s_u):min(j+s_l,m)
+                inbands_setindex!(dest, f(x, inbands_getindex(src, k, j)), k, j)
+            end
+            for k = max(1,j+s_l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -386,13 +386,13 @@ end
     end
 end
 
-function _banded_broadcast_loop!(dest, src, f, s_l_s_u, m)
+@inline function _banded_broadcast_loop!(dest, src, f, s_l_s_u, m)
     for j = rowsupport(dest)
         _banded_broadcast_loop_overlap!(dest, src, f, s_l_s_u, m, j)
     end
 end
 
-function _banded_broadcast_loop!(dest, src, f, z, (s_l, s_u), (d_l, d_u), m)
+@inline function _banded_broadcast_loop!(dest, src, f, z, (s_l, s_u), (d_l, d_u), m)
     min_su_du = min(s_u, d_u)
     min_sl_dl = min(s_l, d_l)
     for j = rowsupport(dest)
@@ -408,7 +408,7 @@ function _banded_broadcast_loop!(dest, src, f, z, (s_l, s_u), (d_l, d_u), m)
     end
 end
 
-function _banded_broadcast_loop_checkbandwidths!(dest, src, f, z, (s_l, s_u), (d_l, d_u), m)
+@inline function _banded_broadcast_loop_checkbandwidths!(dest, src, f, z, (s_l, s_u), (d_l, d_u), m)
     if d_l == s_l && d_u == s_u
         _banded_broadcast_loop!(dest, src, f, (s_l, s_u), m)
     else

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -637,19 +637,19 @@ function _left_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
         if max(-A_u,-u) > min(A_l,l) && max(-u,A_l+1) > l
             return dest
         elseif max(-A_u,-u) > min(A_l,l)
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-u,j+A_l+1):min(j+l,m)
                     inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
                 end
             end
         elseif max(-u,A_l+1) > l
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j+max(-A_u,-u)):min(j+min(A_l,l),m)
                     inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
                 end
             end
         else
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j+max(-A_u,-u)):min(j+min(A_l,l),m)
                     inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
                 end
@@ -659,7 +659,7 @@ function _left_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
             end
         end
     else
-        for j=1:n
+        for j=rowsupport(dest)
             for k = max(1,j-d_u):min(j-u-1,m)
                 inbands_setindex!(dest, z, k, j)
             end
@@ -703,19 +703,19 @@ function _right_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
         if -min(u,n-1) > min(l,B_l) && max(-u,B_l+1) > l
             return dest
         elseif -min(u,n-1) > min(l,B_l)
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-u,j+B_l+1):min(j+l,m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
                 end
             end
         elseif max(-u,B_l+1) > l
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-min(u,n-1)):min(j+min(l,B_l),m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
                 end
             end
         else
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-min(u,n-1)):min(j+min(l,B_l),m)
                     inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
                 end
@@ -725,7 +725,7 @@ function _right_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
             end
         end
     else
-        for j=1:n
+        for j=rowsupport(dest)
             for k = max(1,j-d_u):min(j-u-1,m)
                 inbands_setindex!(dest, z, k, j)
             end
@@ -768,19 +768,19 @@ function _left_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
         if -u > min(-A_u-1,l) && -min(A_u,u) > l
             return dest
         elseif -u > min(-A_u-1,l)
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-min(A_u,u)):min(j+l,m)
                     inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
                 end
             end
         elseif -min(A_u,u) > l
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-u):min(j-A_u-1,j+l,m)
                     inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
                 end
             end
         else
-            for j=1:n
+            for j=rowsupport(dest)
                 for k = max(1,j-u):min(j-A_u-1,j+l,m)
                     inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
                 end
@@ -790,7 +790,7 @@ function _left_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
             end
         end
     else
-        for j=1:n
+        for j=rowsupport(dest)
             for k = max(1,j-d_u):min(j-u-1,m)
                 inbands_setindex!(dest, z, k, j)
             end

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -401,12 +401,26 @@ function _left_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == B_l == l && d_u == B_u == u
-        for j=1:n
-            for k = max(1,j-min(A_u,u)):min(j+min(A_l,l),m)
-                inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
+        if max(-A_u,-u) > min(A_l,l)
+            for j=1:n
+                for k = max(1,j-u,j+A_l+1):min(j+l,m)
+                    inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+                end
             end
-            for k = max(1,j-u,j+A_l+1):min(j+l,m)
-                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+        elseif max(-u,A_l+1) > l
+            for j=1:n
+                for k = max(1,j+max(-A_u,-u)):min(j+min(A_l,l),m)
+                    inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
+                end
+            end
+        else
+            for j=1:n
+                for k = max(1,j+max(-A_u,-u)):min(j+min(A_l,l),m)
+                    inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
+                end
+                for k = max(1,j+max(-u,A_l+1)):min(j+l,m)
+                    inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+                end
             end
         end
     else
@@ -451,12 +465,26 @@ function _right_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == A_l == l && d_u == A_u == u
-        for j=1:n
-            for k = max(1,j-min(u,n-1)):min(j+min(l,B_l),m)
-                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
+        if -min(u,n-1) > min(l,B_l)
+            for j=1:n
+                for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                end
             end
-            for k = max(1,j-u,j+B_l+1):min(j+l,m)
-                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+        elseif max(-u,B_l+1) > l
+            for j=1:n
+                for k = max(1,j-min(u,n-1)):min(j+min(l,B_l),m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
+                end
+            end
+        else
+            for j=1:n
+                for k = max(1,j-min(u,n-1)):min(j+min(l,B_l),m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
+                end
+                for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                end
             end
         end
     else
@@ -500,12 +528,26 @@ function _left_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == B_l == l && d_u == B_u == u
-        for j=1:n
-            for k = max(1,j-u):min(j-A_u-1,j+l,m)
-                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+        if -u > min(-A_u-1,l)
+            for j=1:n
+                for k = max(1,j-min(A_u,u)):min(j+l,m)
+                    inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
+                end
             end
-            for k = max(1,j-min(A_u,u)):min(j+l,m)
-                inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
+        elseif -min(A_u,u) > l
+            for j=1:n
+                for k = max(1,j-u):min(j-A_u-1,j+l,m)
+                    inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+                end
+            end
+        else
+            for j=1:n
+                for k = max(1,j-u):min(j-A_u-1,j+l,m)
+                    inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+                end
+                for k = max(1,j-min(A_u,u)):min(j+l,m)
+                    inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
+                end
             end
         end
     else
@@ -548,12 +590,26 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
     if d_l == A_l == l && d_u == A_u == u
-        for j=1:n
-            for k = max(1,j-u):min(j-B_u-1,j+l,m)
-                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+        if -u > min(-B_u-1, l)
+            for j=1:n
+                for k = max(1,j-min(u,B_u)):min(j+l,m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                end
             end
-            for k = max(1,j-min(u,B_u)):min(j+l,m)
-                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+        elseif -min(u,B_u) > l
+            for j=1:n
+                for k = max(1,j-u):min(j-B_u-1,j+l,m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                end
+            end
+        else
+            for j=1:n
+                for k = max(1,j-u):min(j-B_u-1,j+l,m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+                end
+                for k = max(1,j-min(u,B_u)):min(j+l,m)
+                    inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+                end
             end
         end
     else

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -744,27 +744,35 @@ function _banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{AbstractMatrix
     B_l, B_u = bandwidths(B)
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == A_l == B_l == l && d_u == A_u == B_u == u
+        for j=rowsupport(dest)
+            for k = max(1,j-u):min(j+l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), inbands_getindex(B, k, j)), k, j)
+            end
         end
-        for k = max(1,j-A_u,j-d_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-B_u,j-d_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u),j-d_u):min(j+min(A_l,B_l),j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j+B_l+1,j-d_u):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j+A_l+1,j-d_u):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-d_u,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=rowsupport(dest)
+            for k = max(1,j-d_u):min(j-u-1,j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-A_u,j-d_u):min(j-B_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-B_u,j-d_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-min(A_u,B_u),j-d_u):min(j+min(A_l,B_l),j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j+B_l+1,j-d_u):min(j+A_l,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j+A_l+1,j-d_u):min(j+B_l,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-d_u,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest

--- a/src/interfaceimpl.jl
+++ b/src/interfaceimpl.jl
@@ -24,8 +24,8 @@ inbands_getindex(::Eye{T}, k::Integer, j::Integer) where T = one(T)
 
 isbanded(::Diagonal) = true
 bandwidths(::Diagonal) = (0,0)
-inbands_getindex(D::Diagonal, k::Integer, j::Integer) = D.diag[k]
-inbands_setindex!(D::Diagonal, v, k::Integer, j::Integer) = (D.diag[k] = v)
+Base.@propagate_inbounds inbands_getindex(D::Diagonal, k::Integer, j::Integer) = D.diag[k]
+Base.@propagate_inbounds inbands_setindex!(D::Diagonal, v, k::Integer, j::Integer) = (D.diag[k] = v)
 bandeddata(D::Diagonal) = permutedims(D.diag)
 
 # treat subinds as banded


### PR DESCRIPTION
This PR reduces the number of loops in row/col broadcasts in case bandwidths are preserved, which should provide an `O(n)` improvement for left/right multiplication by a `Diagonal`.

With arrays
```julia
julia> A = BandedMatrix(0=>Float64[1:3000;]); v = rand(size(A,2)); C = copy(A);
```

| Operation | Master | PR|
| --- | :-: | :-: |
| `A .* v` | 50.576 μs | 17.094 μs |
| `A  .* v'` | 51.985 μs | 19.867 μs |
| `v .* A` | 49.867 μs | 16.797 μs |
| `v' .* A` | 58.450 μs | 27.805 μs |
| `C' .= A'` | 26.480 μs | 17.158 μs |
| `C' .= A' .* 2` | 24.535 μs | 17.996 μs |
| `C' .= 2 .* A'` | 24.504 μs |17.972 μs |
| `C .= 2 .* A` | 8.767 μs | 7.899 μs |
| `C .= A .* 2` | 8.397 μs | 7.962 μs |

The performance is largely unaffected if `A` has many bands, in which case the gains from such loop splitting are small compared to the actual computation.