### PR TITLE
brodacast over vec(data) if bandwidths match

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -643,6 +643,8 @@ function _banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{AbstractMatrix
     data_d,data_A, data_B = bandeddata(dest), bandeddata(A), bandeddata(B)
 
     if (d_l,d_u) == (A_l,A_u) == (B_l,B_u)
+        # performance optimization: broadcasting on vec(data) enables vectorization
+        # see https://github.com/JuliaLang/julia/issues/28126
         vec(data_d) .= f.(vec(data_A),vec(data_B))
     else
         max_l,max_u = max(A_l,B_l,d_l),max(A_u,B_u,d_u)

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -643,7 +643,7 @@ function _banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{AbstractMatrix
     data_d,data_A, data_B = bandeddata(dest), bandeddata(A), bandeddata(B)
 
     if (d_l,d_u) == (A_l,A_u) == (B_l,B_u)
-        data_d .= f.(data_A,data_B)
+        vec(data_d) .= f.(vec(data_A),vec(data_B))
     else
         max_l,max_u = max(A_l,B_l,d_l),max(A_u,B_u,d_u)
         min_l,min_u = min(A_l,B_l,d_l),min(A_u,B_u,d_u)


### PR DESCRIPTION
Yet another attempt at https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/pull/285, but conceptually the simplest.
Instead of `data_C .= f.(data_A, data_B)` we may do `vec(data_C) .= f.(vec(data_A), vec(data_B))`. As long as the data supports reshaping, these should be equivalent. However, this automatically enables vectorization, leading to performance improvements

On master
```julia
julia> B = BandedMatrix(1=>Float64.(1:3000));

julia> @btime $B .* $B;
  11.024 μs (3 allocations: 23.59 KiB)
```

This PR
```julia
julia> @btime $B .* $B;
  2.677 μs (9 allocations: 23.83 KiB)
```

Performance seems unaffected in `InfiniteLinearAlgebra`, where infinite banded matrices are used
```julia
julia> A = BandedMatrix(0 => -2*(0:∞), 1 => Ones(∞), -1 => Ones(∞));

julia> @btime $A .* $A; # This PR, same as master
  2.941 ns (0 allocations: 0 bytes)
```

Something similar would also be possible when broadcasting numbers, but that can be a separate PR if this seems reasonable.