### PR TITLE
Throw error in broadcasting to fewer bands

### DIFF
--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -73,7 +73,7 @@ BandError(A::AbstractMatrix) = BandError(A, max(size(A)...)-1)
 
 function showerror(io::IO, e::BandError)
     A, i = e.A, e.i
-    print(io, "attempt to access $(typeof(A)) with bandwidths " *
+    print(io, "BandError: attempt to access $(typeof(A)) with bandwidths " *
               "($(bandwidth(A, 1)), $(bandwidth(A, 2))) at band $i")
 end
 


### PR DESCRIPTION
Currently, on master,
```julia
julia> D = brand(4, 4, -2, 1) # empty
4×4 BandedMatrix{Float64} with bandwidths (-2, 1):
  ⋅    ⋅    ⋅    ⋅ 
  ⋅    ⋅    ⋅    ⋅ 
  ⋅    ⋅    ⋅    ⋅ 
  ⋅    ⋅    ⋅    ⋅ 

julia> B = brand(size(D)...,1,2) # non-empty and non-zero bands
4×4 BandedMatrix{Float64} with bandwidths (1, 2):
 0.867543  0.104975  0.812628   ⋅ 
 0.954679  0.96598   0.396831  0.427929
  ⋅        0.457686  0.563948  0.429046
  ⋅         ⋅        0.258889  0.308205

julia> D .= B # errors correctly
ERROR: attempt to access BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}} with bandwidths (-2, 1) at band 0
Stacktrace:
 [1] checkzerobands(dest::BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, f::typeof(identity), A::BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}})
   @ BandedMatrices ~/Dropbox/JuliaPackages/BandedMatrices.jl/src/generic/broadcast.jl:86
 [2] _banded_broadcast!(dest::BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, f::typeof(identity), A::BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, #unused#::BandedMatrices.BandedColumns{ArrayLayouts.DenseColumnMajor}, #unused#::BandedMatrices.BandedColumns{ArrayLayouts.DenseColumnMajor})
   @ BandedMatrices ~/Dropbox/JuliaPackages/BandedMatrices.jl/src/generic/broadcast.jl:187
 [3] copyto!
   @ ~/Dropbox/JuliaPackages/BandedMatrices.jl/src/generic/broadcast.jl:238 [inlined]
 [4] materialize!
   @ ./broadcast.jl:884 [inlined]
 [5] materialize!(dest::BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, bc::Base.Broadcast.Broadcasted{BandedMatrices.BandedStyle, Nothing, typeof(identity), Tuple{BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}}})
   @ Base.Broadcast ./broadcast.jl:881
 [6] top-level scope
   @ REPL[4]:1

julia> D' .= B' # works, when it shouldn't
4×4 adjoint(::BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}) with eltype Float64:
  ⋅    ⋅    ⋅    ⋅ 
  ⋅    ⋅    ⋅    ⋅ 
  ⋅    ⋅    ⋅    ⋅ 
  ⋅    ⋅    ⋅    ⋅ 
```
This PR changes the latter to error as well:
```julia
julia> D' .= B'
ERROR: BandError: attempt to access LinearAlgebra.Adjoint{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}} with bandwidths (1, -2) at band 0
[...]
```