### PR TITLE
Bandwidth-preserving branches in row/col broadcast

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -385,30 +385,39 @@ function _left_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
 
     d_l, d_u = bandwidths(dest)
     A_l, A_u = _broadcast_bandwidths((m-1,n-1),A)
+    @assert A_u == n-1
     B_l, B_u = bandwidths(B)
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == B_l == l && d_u == B_u == u
+        for j=rowsupport(dest)
+            for k = max(1,j-u):min(j+min(A_l,l),m)
+                inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-u,j+A_l+1):min(j+l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(A[k], zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(A[k], zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=rowsupport(dest)
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u):min(j-B_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(A[k], zero(V)), k, j)
+            end
+            for k = max(1,j-B_u):min(j+min(A_l,B_l),m)
+                inbands_setindex!(dest, f(A[k], inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
+                inbands_setindex!(dest, f(A[k], zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest
@@ -427,29 +436,38 @@ function _right_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     d_l, d_u = bandwidths(dest)
     A_l, A_u = bandwidths(A)
     B_l, B_u = _broadcast_bandwidths((m-1,n-1),B)
+    @assert B_u == n-1
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == A_l == l && d_u == A_u == u
+        for j=rowsupport(dest)
+            for k = max(1,j-u):min(j+min(l,B_l),m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
+            end
+            for k = max(1,j-u,j+B_l+1):min(j+l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[k]), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[k]), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=rowsupport(dest)
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[k]), k, j)
+            end
+            for k = max(1,j-A_u):min(j+min(A_l,B_l),m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[k]), k, j)
+            end
+            for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[k]), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest
@@ -465,30 +483,39 @@ function _left_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
 
     d_l, d_u = bandwidths(dest)
     A_l, A_u = _broadcast_bandwidths((m-1,n-1),A)
+    @assert A_l == m-1
     B_l, B_u = bandwidths(B)
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == B_l == l && d_u == B_u == u
+        for j=rowsupport(dest)
+            for k = max(1,j-u):min(j-A_u-1,j+l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-min(A_u,u)):min(j+l,m)
+                inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(A[j], zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(A[j], zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=rowsupport(dest)
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(A[j], zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
+                inbands_setindex!(dest, f(A[j], inbands_getindex(B, k, j)), k, j)
+            end
+            for k = max(1,j-d_u,j+B_l+1):min(j+d_l,m)
+                inbands_setindex!(dest, f(A[j], zero(V)), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest
@@ -505,29 +532,38 @@ function _right_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
     d_l, d_u = bandwidths(dest)
     A_l, A_u = bandwidths(A)
     B_l, B_u = _broadcast_bandwidths((m-1,n-1),B)
+    @assert B_l ==  m-1
     (d_l ≥ min(l,m-1) && d_u ≥ min(u,n-1)) || throw(BandError(dest))
 
-    for j=1:n
-        for k = max(1,j-d_u):min(j-u-1,m)
-            inbands_setindex!(dest, z, k, j)
+    if d_l == A_l == l && d_u == A_u == u
+        for j=rowsupport(dest)
+            for k = max(1,j-u):min(j-B_u-1,j+l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-min(u,B_u)):min(j+l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+            end
         end
-        for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[j]), k, j)
-        end
-        for k = max(1,j-min(A_u,B_u)):min(j+min(A_l,B_l),m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
-        end
-        for k = max(1,j-d_u,j+B_l+1):min(j+A_l,j+d_l,m)
-            inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
-        end
-        for k = max(1,j-d_u,j+A_l+1):min(j+B_l,j+d_l,m)
-            inbands_setindex!(dest, f(zero(T), B[j]), k, j)
-        end
-        for k = max(1,j+l+1):min(j+d_l,m)
-            inbands_setindex!(dest, z, k, j)
+    else
+        for j=rowsupport(dest)
+            for k = max(1,j-d_u):min(j-u-1,m)
+                inbands_setindex!(dest, z, k, j)
+            end
+            for k = max(1,j-d_u,j-A_u):min(j-B_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), zero(V)), k, j)
+            end
+            for k = max(1,j-d_u,j-B_u):min(j-A_u-1,j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[j]), k, j)
+            end
+            for k = max(1,j-min(A_u,B_u)):min(j+A_l,m)
+                inbands_setindex!(dest, f(inbands_getindex(A, k, j), B[j]), k, j)
+            end
+            for k = max(1,j-d_u,j+A_l+1):min(j+d_l,m)
+                inbands_setindex!(dest, f(zero(T), B[j]), k, j)
+            end
+            for k = max(1,j+l+1):min(j+d_l,m)
+                inbands_setindex!(dest, z, k, j)
+            end
         end
     end
     dest

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -430,29 +430,30 @@ import BandedMatrices: BandedStyle, BandedRows
         b = randn(n)
 
         @testset "implicit dest" begin
-            @test b .* A == b .* Matrix(A)
-            @test b .* A isa BandedMatrix
-            @test bandwidths(b .* A) == bandwidths(A)
-            @test A .* b == Matrix(A) .* b
-            @test A .* b isa BandedMatrix
-            @test bandwidths(A .* b) == bandwidths(A)
-            @test b .\ A == b .\ Matrix(A)
-            @test b .\ A isa BandedMatrix
-            @test bandwidths(b .\ A) == bandwidths(A)
-            @test A ./ b == Matrix(A) ./ b
-            @test A ./ b isa BandedMatrix
-            @test bandwidths(A ./ b) == bandwidths(A)
+            for A_ in (A, A'), b_ in (b, BandedMatrix(b')')
+                @test b_ .* A_ == b_ .* Matrix(A_)
+                @test b_ .* A_ isa BandedMatrix
+                @test bandwidths(b_ .* A_) == bandwidths(A_)
+                @test b_' .* A_ == b_' .* Matrix(A_)
+                @test b_' .* A_ isa BandedMatrix
+                @test bandwidths(b_' .* A_) == bandwidths(A_)
+                @test A_ .* b_ == Matrix(A_) .* b_
+                @test A_ .* b_ isa BandedMatrix
+                @test bandwidths(A_ .* b_) == bandwidths(A_)
+                @test A_ .* b_' == Matrix(A_) .* b_'
+                @test A_ .* b_' isa BandedMatrix
+                @test bandwidths(A_ .* b_') == bandwidths(A_)
+                @test b_ .\ A_ == b_ .\ Matrix(A_)
+                @test b_ .\ A_ isa BandedMatrix
+                @test bandwidths(b_ .\ A_) == bandwidths(A_)
+                @test A_ ./ b_ == Matrix(A_) ./ b_
+                @test A_ ./ b_ isa BandedMatrix
+                @test bandwidths(A_ ./ b_) == bandwidths(A_)
+            end
 
             @test bandwidths(Broadcast.broadcasted(/, b, A)) == (9,9)
             @test isinf((b ./ A)[4,1])
             @test bandwidths(Broadcast.broadcasted(\, A,b)) == (9,9)
-            @test isinf((A .\ b)[4,1])
-
-
-            @test A .* b == Matrix(A) .* b
-            @test bandwidths(A .* b) == bandwidths(A)
-            @test A ./ b == Matrix(A) ./ b
-            @test bandwidths(A ./ b) == bandwidths(A)
             @test isinf((A .\ b)[4,1])
 
             @test reshape(b,10,1) .* A isa BandedMatrix
@@ -465,8 +466,6 @@ import BandedMatrices: BandedStyle, BandedRows
             @test bandwidths(broadcasted(+, A, b')) == (9,9)
             @test A .+ b' == b' .+ A == Matrix(A) .+ b'
             @test bandwidths(A .+ b') == bandwidths(b' .+ A)  == (9,9)
-            @test A .* b' == b' .* A == Matrix(A) .* b'
-            @test bandwidths(A .* b') == bandwidths(b' .* A) == bandwidths(A)
 
             @testset "nested broadcast" begin
                 @test bandwidths((b ./ 2) .* A) == (1,2)
@@ -478,21 +477,20 @@ import BandedMatrices: BandedStyle, BandedRows
             D = brand(size(A)..., (bandwidths(A) .+ 1)...)
             D .= 0
 
-            for (A_, D_) in ((A,D), (A', D'))
-                D_ .= b .* A_
-                @test D_ == b .* A_
+            for (A_, D_) in ((A,D), (A', D')), b_ in (b, BandedMatrix(b')')
+                D_ .= b_ .* A_
+                @test D_ == b_ .* A_
 
-                D_ .= b' .* A_
-                @test D_ == b' .* A_
+                D_ .= b_' .* A_
+                @test D_ == b_' .* A_
 
-                D_ .= A_ .* b
-                @test D_ == A_ .* b
+                D_ .= A_ .* b_
+                @test D_ == A_ .* b_
 
-                D_ .= A_ .* b'
-                @test D_ == A_ .* b'
+                D_ .= A_ .* b_'
+                @test D_ == A_ .* b_'
             end
         end
-
     end
 
     @testset "views" begin


### PR DESCRIPTION
This helps with performance in `A .* b` type cases

With arrays
```julia
A = BandedMatrix(0=>Float64[1:3000;]); v = rand(size(A,1));
```
| Operation | Master | PR |
| --- | :-: | :-: |
| `A .* v` | 50.560 μs | 19.609 μs |
| `v .* A` | 49.867 μs | 23.308 μs |
| `A .* v'` | 51.944 μs| 10.112 μs |
| `v' .* A` | 58.198 μs| 10.388 μs |