### PR TITLE
rowsupport in indexing in checkzerobands

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -78,7 +78,7 @@ function checkzerobands(dest, f, A::AbstractMatrix)
     l, u = bandwidths(A)
 
     if (l,u) ≠ (d_l,d_u)
-        for j = 1:n
+        for j = rowsupport(A)
             for k = max(1,j-u) : min(j-d_u-1,m)
                 iszero(f(A[k,j])) || throw(BandError(dest,j-k))
             end


### PR DESCRIPTION
To check for zero values, we only need to check the filled bands, and not all columns.

On master
```julia
julia> B = brand(1,1000,0,1); B .= 0; B
1×1000 BandedMatrix{Float64} with bandwidths (0, 1):
 0.0  0.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅ 

julia> C = brand(size(B)...,0,0); C .= 0; C
1×1000 BandedMatrix{Float64} with bandwidths (0, 0):
 0.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅ 

julia> @btime BandedMatrices.checkzerobands($C, *, $B);
  3.792 μs (0 allocations: 0 bytes)

julia> @btime $C .= $B;
  3.905 μs (0 allocations: 0 bytes)
```
This PR
```julia
julia> @btime BandedMatrices.checkzerobands($C, *, $B);
  21.516 ns (0 allocations: 0 bytes)

julia> @btime $C .= $B;
  111.169 ns (0 allocations: 0 bytes)
```
Most of the time was spent in unnecessary zero checks.