### PR TITLE
Fallback function broadcast zero check

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -300,8 +300,6 @@ function _banded_broadcast!(dest::AbstractMatrix, f, (x,src)::Tuple{Number,Abstr
     d_l, d_u = bandwidths(dest)
     s_l, s_u = bandwidths(src)
 
-    checkzerobands(dest, f, src)
-
     _banded_broadcast_anylayout!(dest, src, f_x, z, (s_l, s_u), (d_l, d_u), m)
 
     dest

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -99,6 +99,11 @@ import BandedMatrices: BandedStyle, BandedRows
         A .= B
         @test A == B
 
+        B = brand(1,4,0,1)
+        C = brand(size(B)...,0,0)
+        @test_throws BandError C .= B
+        @test_throws BandError C' .= B'
+
         @testset "empty dest" begin
             test_empty((D,B) -> D .= B)
         end


### PR DESCRIPTION
On master
```julia
julia> B = brand(1,4,0,1)
1×4 BandedMatrix{Float64} with bandwidths (0, 1):
 0.743297  0.461126   ⋅    ⋅ 

julia> C = brand(size(B)...,0,0)
1×4 BandedMatrix{Float64} with bandwidths (0, 0):
 0.172887   ⋅    ⋅    ⋅ 

julia> C' .= B'; C
1×4 BandedMatrix{Float64} with bandwidths (0, 0):
 0.743297   ⋅    ⋅    ⋅ 
```
This PR fixes this, and this throws an error now, as it should.
```julia
julia> C' .= B'
ERROR: BandError: attempt to access Adjoint{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}} with bandwidths (0, 0) at band -1
```