### PR TITLE
rowsupport in checkzerobands for two matrices

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -681,7 +681,9 @@ function checkzerobands(dest, f, (A,B)::Tuple{AbstractMatrix,AbstractMatrix})
     B_l, B_u = bandwidths(B)
     l, u = max(A_l,B_l), max(A_u,B_u)
 
-    for j = 1:n
+    rspA = rowsupport(A)
+    rspB = rowsupport(B)
+    for j = min(minimum(rspA), minimum(rspB)):max(maximum(rspA), maximum(rspB))
         for k = max(1,j-u) : min(j-d_u-1,m)
             iszero(f(A[k,j], B[k,j])) || throw(BandError(dest,b))
         end

--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -77,7 +77,7 @@ function checkzerobands(dest, f, A::AbstractMatrix)
     d_l, d_u = bandwidths(dest)
     l, u = bandwidths(A)
 
-    if (l,u) ≠ (d_l,d_u)
+    if !(d_l >= l && d_u >= u)
         for j = rowsupport(A)
             for k = max(1,j-u) : min(j-d_u-1,m)
                 iszero(f(A[k,j])) || throw(BandError(dest,j-k))


### PR DESCRIPTION
On master
```julia
julia> B = brand(2,1000,1,0);

julia> C = brand(size(B)..., bandwidths(B)...);

julia> D = zero(C);

julia> @btime BandedMatrices.checkzerobands($D, *, ($B,$C));
  4.204 μs (0 allocations: 0 bytes)
```
This PR
```julia
julia> @btime BandedMatrices.checkzerobands($D, *, ($B,$C));
  34.958 ns (0 allocations: 0 bytes)
```

Also, on master:
```julia
julia> B = brand(2,1000,1,80);

julia> C = brand(size(B)..., (bandwidths(B) .+ 1)...);

julia> @btime BandedMatrices.checkzerobands($C, identity, $B);
  329.283 ns (0 allocations: 0 bytes)
```
This PR
```julia
julia> @btime BandedMatrices.checkzerobands($C, identity, $B);
  7.126 ns (0 allocations: 0 bytes)
```