### PR TITLE
Remove Rmul Diagonal specialization

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -816,29 +816,6 @@ function copy(bc::Broadcasted{BandedStyle, <:Any, <:Any, <:Tuple{<:AbstractMatri
 end
 
 ###
-# Special cases
-###
-
-#=
-    B::BandedMatrix * D::Diagonal for DenseColumnMajor storage may be evaluated as
-    B.data .* D.diag', instead of B .* D.diag'
-=#
-function copy(M::Rmul{BandedColumns{DenseColumnMajor}, DiagonalLayout{DenseColumnMajor}})
-    B, D = M.A, M.B
-    d = diagonaldata(D)
-    Bd = bandeddata(B)
-    Bdata = if size(Bd, 1) == 1
-                # performance optimization
-                # may not be necessary in the future if the other branch
-                # is equally fast
-                reshape(vec(Bd) .* d, 1, :)
-            else
-                Bd .* d'
-            end
-    _BandedMatrix(Bdata, size(B,1), bandwidths(B)...)
-end
-
-###
 # broadcast bandwidths
 ###
 


### PR DESCRIPTION
Now that `A .* v'` is fast, specializing `A * D` is largely unnecessary. The performance would be improved further by https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl/pull/118.