### PR TITLE
Remove copy methods

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -768,53 +768,6 @@ end
 copyto!(dest::AbstractArray, bc::Broadcasted{BandedStyle, <:Any, <:Any, <:Tuple{<:AbstractMatrix,<:AbstractMatrix}}) =
     _banded_broadcast!(dest, bc.f, bc.args, MemoryLayout(typeof(dest)), map(MemoryLayout,bc.args))
 
-# override copy in case data has special broadcast
-_default_banded_broadcast(bc::Broadcasted{Style}, _) where Style = Base.invoke(copy, Tuple{Broadcasted{Style}}, bc)
-_default_banded_broadcast(bc::Broadcasted) = _default_banded_broadcast(bc, axes(bc))
-
-_banded_broadcast(f, args::Tuple, _...) = _default_banded_broadcast(broadcasted(f, args...))
-_banded_broadcast(f, arg, _...) = _default_banded_broadcast(broadcasted(f, arg))
-
-function _banded_broadcast(f, A::AbstractMatrix{T}, ::BandedColumns) where T
-    iszero(f(zero(T))) || return _default_banded_broadcast(broadcasted(f, A))
-    Bdata = bandeddata(A)
-    Bdata_new = reshape(f.(vec(Bdata)), size(Bdata))
-    _BandedMatrix(Bdata_new, axes(A,1), bandwidths(A)...)
-end
-function _banded_broadcast(f, (src,x)::Tuple{AbstractMatrix{T},Number}, ::BandedColumns) where T
-    iszero(f(zero(T),x)) || return _default_banded_broadcast(broadcasted(f, src,x))
-    Bdata = bandeddata(src)
-    Bdata_new = reshape(f.(vec(Bdata), x), size(Bdata))
-    _BandedMatrix(Bdata_new, axes(src,1), bandwidths(src)...)
-end
-function _banded_broadcast(f, (x, src)::Tuple{Number,AbstractMatrix{T}}, ::BandedColumns) where T
-    iszero(f(x, zero(T))) || return _default_banded_broadcast(broadcasted(f, x,src))
-    Bdata = bandeddata(src)
-    Bdata_new = reshape(f.(x, vec(Bdata)), size(Bdata))
-    _BandedMatrix(Bdata_new, axes(src,1), bandwidths(src)...)
-end
-
-function copy(bc::Broadcasted{BandedStyle, <:Any, <:Any, <:Tuple{<:AbstractMatrix}})
-    (A,) = bc.args
-    _banded_broadcast(bc.f, A, MemoryLayout(typeof(A)))
-end
-
-function copy(bc::Broadcasted{BandedStyle, <:Any, <:Any, <:Tuple{<:AbstractMatrix,<:Number}})
-    (A,x) = bc.args
-    _banded_broadcast(bc.f, (A, x), MemoryLayout(typeof(A)))
-end
-
-
-function copy(bc::Broadcasted{BandedStyle, <:Any, <:Any, <:Tuple{<:Number,<:AbstractMatrix}})
-    (x,A) = bc.args
-    _banded_broadcast(bc.f, (x,A), MemoryLayout(typeof(A)))
-end
-
-
-function copy(bc::Broadcasted{BandedStyle, <:Any, <:Any, <:Tuple{<:AbstractMatrix,<:AbstractMatrix}})
-    _banded_broadcast(bc.f, bc.args, MemoryLayout.(typeof.(bc.args)))
-end
-
 ###
 # Special cases
 ###


### PR DESCRIPTION
Since `copyto!` is specialized already, there should be no need to specialize these `copy` methods as well. Some of these were using the linear indexing trick, but it's best to be consistent in what's being done.