### PR TITLE
Fast path for DenseColumnMajor row broadcast

### DIFF
--- a/src/generic/broadcast.jl
+++ b/src/generic/broadcast.jl
@@ -477,7 +477,8 @@ function _right_colvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{A
 end
 
 function __left_rowvec_banded_broadcast!(dest, f, (A,B),
-        ::BandedColumns, ::Tuple{DualLayout{ArrayLayouts.DenseRowMajor}, BandedColumns},
+        ::BandedColumns,
+        ::Tuple{Union{DenseColumnMajor, DualLayout{ArrayLayouts.DenseRowMajor}}, BandedColumns},
         (l, u), (A_l,A_u), (m,n))
 
     D = bandeddata(dest)
@@ -540,7 +541,8 @@ function _left_rowvec_banded_broadcast!(dest::AbstractMatrix, f, (A,B)::Tuple{Ab
 end
 
 function __right_rowvec_banded_broadcast!(dest, f, (A,B),
-        ::BandedColumns, ::Tuple{BandedColumns, DualLayout{ArrayLayouts.DenseRowMajor}},
+        ::BandedColumns,
+        ::Tuple{BandedColumns, Union{DualLayout{ArrayLayouts.DenseRowMajor}, DenseColumnMajor}},
         (l, u), (B_l,B_u), (m,n))
 
     D = bandeddata(dest)

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -491,15 +491,26 @@ import BandedMatrices: BandedStyle, BandedRows
                 @test b_ .* A_ == b_ .* Matrix(A_)
                 @test b_ .* A_ isa BandedMatrix
                 @test bandwidths(b_ .* A_) == bandwidths(A_)
+
                 @test b_' .* A_ == b_' .* Matrix(A_)
                 @test b_' .* A_ isa BandedMatrix
                 @test bandwidths(b_' .* A_) == bandwidths(A_)
+
+                @test permutedims(b_) .* A_ == permutedims(b_) .* Matrix(A_)
+                @test permutedims(b_) .* A_ isa BandedMatrix
+                @test bandwidths(permutedims(b_) .* A_) == bandwidths(A_)
+
                 @test A_ .* b_ == Matrix(A_) .* b_
                 @test A_ .* b_ isa BandedMatrix
                 @test bandwidths(A_ .* b_) == bandwidths(A_)
+
                 @test A_ .* b_' == Matrix(A_) .* b_'
                 @test A_ .* b_' isa BandedMatrix
                 @test bandwidths(A_ .* b_') == bandwidths(A_)
+
+                @test A_ .* permutedims(b_) == Matrix(A_) .* permutedims(b_)
+                @test A_ .* permutedims(b_) isa BandedMatrix
+                @test bandwidths(A_ .* permutedims(b_)) == bandwidths(A_)
             end
 
             # division tests currently don't deal with Inf/NaN correctly,
@@ -546,11 +557,17 @@ import BandedMatrices: BandedStyle, BandedRows
                 D_ .= b_' .* A_
                 @test D_ == b_' .* A_
 
+                D_ .= permutedims(b_) .* A_
+                @test D_ == permutedims(b_) .* A_
+
                 D_ .= A_ .* b_
                 @test D_ == A_ .* b_
 
                 D_ .= A_ .* b_'
                 @test D_ == A_ .* b_'
+
+                D_ .= A_ .* permutedims(b_)
+                @test D_ == A_ .* permutedims(b_)
             end
         end
     end


### PR DESCRIPTION
This makes `A .* v'` and `A .* permutedims(v)` equally performant.