### PR TITLE
Matching bandwidth branch in banded broadcast

### DIFF
--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -96,20 +96,4 @@ include("interfaceimpl.jl")
 
 include("precompile.jl")
 
-# function _precompile_()
-#     precompile(Tuple{typeof(gbmm!), Char, Char, Float64, BandedMatrix{Float64,Array{Float64,2},Base.OneTo{Int64}}, BandedMatrix{Float64,Array{Float64,2},Base.OneTo{Int64}}, Float64, BandedMatrix{Float64,Array{Float64,2},Base.OneTo{Int64}}})
-# end
-
-# _precompile_()
-
-# precompile instructions
-let B = BandedMatrix(0=>zeros(0)), v = zeros(size(B,2))
-    BT = typeof(B)
-    vT = typeof(v)
-    @assert precompile(+, (BT, BT))
-    @assert precompile(-, (BT,))
-    @assert precompile(-, (BT, BT))
-    @assert precompile(*, (BT, vT))
-end
-
 end #module


### PR DESCRIPTION
Bugfixes in untested branches of `__right_rowvec_banded_broadcast` and `__left_rowvec_banded_broadcast`, and a bandwidth-matching branch in `__banded_broadcast` which helps with performance.

On master
```julia
julia> B = brand(5000,5000,0,0);

julia> @btime $B' .+ $B';
  113.291 μs (3 allocations: 39.16 KiB)
```
This PR
```julia
julia> @btime $B' .+ $B';
  44.939 μs (3 allocations: 39.16 KiB)
```

Some redundant precompile statements are removed.