### PR TITLE
Faster band indexing for BandedMatrix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,13 +17,8 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.develop(PackageSpec(; path=pwd()))
             Pkg.instantiate()'
-      - run: |
-          julia --project=docs -e '
-            using Documenter: doctest
-            using BandedMatrices
-            doctest(BandedMatrices)'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.14"
+version = "0.17.15"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, BandedMatrices
 
-DocMeta.setdocmeta!(BandedMatrices, :DocTestSetup, :(using BandedMatrices))
+DocMeta.setdocmeta!(BandedMatrices, :DocTestSetup, :(using BandedMatrices); recursive=true)
 makedocs(;
     modules = [BandedMatrices],
     format = Documenter.HTML(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,6 @@
 using Documenter, BandedMatrices
 
+DocMeta.setdocmeta!(BandedMatrices, :DocTestSetup, :(using BandedMatrices))
 makedocs(;
     modules = [BandedMatrices],
     format = Documenter.HTML(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,18 +3,14 @@ using Documenter, BandedMatrices
 DocMeta.setdocmeta!(BandedMatrices, :DocTestSetup, :(using BandedMatrices); recursive=true)
 makedocs(;
     modules = [BandedMatrices],
-    format = Documenter.HTML(
-        canonical = "https://JuliaMatrices.github.io/BandedMatrices.jl/stable/",
-    ),
     pages = [
         "Home" => "index.md",
     ],
-    repo = "https://github.com/JuliaMatrices/BandedMatrices.jl/blob/{commit}{path}#L{line}",
     sitename = "BandedMatrices.jl",
     authors = "Sheehan Olver, Mikael Slevinsky, and contributors.",
 )
 
 
 deploydocs(;
-    repo   = "github.com/JuliaMatrices/BandedMatrices.jl.git"
+    repo   = "github.com/JuliaLinearAlgebra/BandedMatrices.jl.git"
     )

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -7,7 +7,7 @@ import Base: axes, axes1, getproperty, getindex, setindex!, *, +, -, ==, <, <=, 
                >=, /, ^, \, adjoint, transpose, showerror, convert, size, view,
                unsafe_indices, first, last, size, length, unsafe_length, step, to_indices,
                to_index, show, fill!, similar, copy, promote_rule, IndexStyle, real, imag,
-               copyto!
+               copyto!, Array
 
 using Base.Broadcast: AbstractArrayStyle, DefaultArrayStyle, Broadcasted
 import Base.Broadcast: BroadcastStyle, broadcasted, materialize, materialize!

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -453,7 +453,8 @@ function copyto!(v::Vector, B::BandedMatrixBand)
     if -A.l ≤ band(B) ≤ A.u
         copyto!(v, dataview(B))
     else
-        v .= 0
+        Binds = axes(B,1)
+        v[Binds] .= 0
     end
     return v
 end

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -401,7 +401,7 @@ end
 Type to represent a view of a band of a `BandedMatrix`
 
 # Examples
-```jldoctest
+```jldoctest; setup=:(using BandedMatrices)
 julia> B = BandedMatrix(0=>1:3);
 
 julia> view(B, band(0)) isa BandedMatrices.BandedMatrixBand
@@ -420,7 +420,7 @@ band(V::BandedMatrixBand) = first(parentindices(V)).band.i
 Forward a view of a band of a `BandedMatrix` to the parent's data matrix.
 
 # Examples
-```jldoctest
+```jldoctest; setup=:(using BandedMatrices)
 julia> A = BandedMatrix(0=>1:4, 1=>5:7, -1=>8:10)
 4×4 BandedMatrix{Int64} with bandwidths (1, 1):
  1  5   ⋅  ⋅

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -401,7 +401,7 @@ end
 Type to represent a view of a band of a `BandedMatrix`
 
 # Examples
-```jldoctest; setup=:(using BandedMatrices)
+```jldoctest
 julia> B = BandedMatrix(0=>1:3);
 
 julia> view(B, band(0)) isa BandedMatrices.BandedMatrixBand
@@ -420,7 +420,7 @@ band(V::BandedMatrixBand) = first(parentindices(V)).band.i
 Forward a view of a band of a `BandedMatrix` to the parent's data matrix.
 
 # Examples
-```jldoctest; setup=:(using BandedMatrices)
+```jldoctest
 julia> A = BandedMatrix(0=>1:4, 1=>5:7, -1=>8:10)
 4×4 BandedMatrix{Int64} with bandwidths (1, 1):
  1  5   ⋅  ⋅

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -184,7 +184,7 @@ the indices over which the `Band` spans.
 This mimics the relationship between `Colon` and `Base.Slice`.
 
 # Example
-```jldoctest; setup=:(using BandedMatrices)
+```jldoctest
 julia> B = BandedMatrix(0 => 1:4, 1=>1:3);
 
 julia> to_indices(B, (Band(1),))[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Aqua
 end
 
 using Documenter
+DocMeta.setdocmeta!(BandedMatrices, :DocTestSetup, :(using BandedMatrices))
 @testset "doctests" begin
     doctest(BandedMatrices)
 end


### PR DESCRIPTION
The type `BandedMatrixBand` wasn't defined properly, so the `dataview` function was never being hit. This fixes the dispatch and improves performance.

On master
```julia
julia> B = BandedMatrix(0=>rand(1000));

julia> @btime $B[band(0)];
  9.535 μs (1 allocation: 7.94 KiB)
```
This PR
```julia
julia> @btime $B[band(0)];
  971.582 ns (1 allocation: 7.94 KiB)
```

Also, removed a bunch of unnecessary `convert` methods