### PR TITLE
Generalize indexing a BandSlice

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.15"
+version = "0.17.16"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -211,7 +211,7 @@ for f in (:indices, :unsafe_indices, :axes1, :first, :last, :size, :length,
     @eval $f(S::BandSlice) = $f(S.indices)
 end
 
-getindex(S::BandSlice, i::Union{Int, AbstractVector}) = getindex(S.indices, i)
+getindex(S::BandSlice, i::Union{Int, AbstractRange}) = getindex(S.indices, i)
 show(io::IO, r::BandSlice) = print(io, "BandSlice(", r.band, ", ", r.indices, ")")
 
 to_index(::Band) = throw(ArgumentError("Block must be converted by to_indices(...)"))

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -211,6 +211,8 @@ for f in (:indices, :unsafe_indices, :axes1, :first, :last, :size, :length,
     @eval $f(S::BandSlice) = $f(S.indices)
 end
 
+Base.reindex(S::Tuple{BandSlice}, i::Tuple{Any}) = Base.reindex((S[1].indices,), i)
+
 getindex(S::BandSlice, i::Int) = getindex(S.indices, i)
 show(io::IO, r::BandSlice) = print(io, "BandSlice(", r.band, ", ", r.indices, ")")
 

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -211,9 +211,7 @@ for f in (:indices, :unsafe_indices, :axes1, :first, :last, :size, :length,
     @eval $f(S::BandSlice) = $f(S.indices)
 end
 
-Base.reindex(S::Tuple{BandSlice}, i::Tuple{Any}) = Base.reindex((S[1].indices,), i)
-
-getindex(S::BandSlice, i::Int) = getindex(S.indices, i)
+getindex(S::BandSlice, i::Union{Int, AbstractVector}) = getindex(S.indices, i)
 show(io::IO, r::BandSlice) = print(io, "BandSlice(", r.band, ", ", r.indices, ")")
 
 to_index(::Band) = throw(ArgumentError("Block must be converted by to_indices(...)"))

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -670,6 +670,14 @@ import BandedMatrices: rowstart, rowstop, colstart, colstop,
         end
     end
 
+    @testset "views of band views" begin
+        A = BandedMatrix(0=>1:4, 1=>(1:3) .+ 5, -1=>(1:3) .+ 10)
+        v = @view A[band(1)]
+        w = view(v, 2:3)
+        @test w == [7,8]
+        @test parentindices(w) isa Tuple{AbstractRange}
+    end
+
     @testset "other special indexing" begin
         @testset "all elements" begin
             a = BandedMatrix(Ones(3, 3), (1, 1))


### PR DESCRIPTION
This is necessary to prevent views of band-views from allocating a vector of indices.
On master
```julia
julia> A = BandedMatrix(0=>1:4, 1=>(1:3) .+ 5, -1=>(1:3) .+ 10)
4×4 BandedMatrix{Int64} with bandwidths (1, 1):
  1   6   ⋅  ⋅
 11   2   7  ⋅
  ⋅  12   3  8
  ⋅   ⋅  13  4

julia> v = @view A[band(1)]
3-element view(reshape(::BandedMatrix{Int64, Matrix{Int64}, Base.OneTo{Int64}}, 16), BandSlice(Band(1), 5:5:15)) with eltype Int64:
 6
 7
 8

julia> w = view(v, 2:3)
2-element view(reshape(::BandedMatrix{Int64, Matrix{Int64}, Base.OneTo{Int64}}, 16), [10, 15]) with eltype Int64:
 7
 8
```
The `parentindices` of `w` is a vector. This is terrible for performance, as in-place broadcasting will perform unaliasing, which will repeatedly keep copying the vector.
This PR
```julia
julia> w = view(v, 2:3)
2-element view(reshape(::BandedMatrix{Int64, Matrix{Int64}, Base.OneTo{Int64}}, 16), 10:5:15) with eltype Int64:
 7
 8
```
Now, the `parentindices` is a range. 