### PR TITLE
Conditionally skip loops in two-term checkzerobands

### DIFF
--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -1,7 +1,7 @@
 using BandedMatrices, LinearAlgebra, ArrayLayouts, FillArrays, Test
 import Base: BroadcastStyle
 import Base.Broadcast: broadcasted
-import BandedMatrices: BandedStyle, BandedRows
+import BandedMatrices: BandedStyle, BandedRows, BandError
 
 @testset "broadcasting" begin
     @testset "general" begin
@@ -46,6 +46,15 @@ import BandedMatrices: BandedStyle, BandedRows
             @test A[:,1] isa Vector
             @test norm(A .- A[:,1]) == 0
             @test A ≈ A[:,1]
+        end
+
+        @testset "checkzerobands" begin
+            A = brand(4,4, 1,1)
+            for (l,u) in ((0,0), (0,1), (1,0))
+                dest = brand(size(A)..., l,u)
+                @test_throws BandError dest .= A .+ A
+                @test_throws BandError dest .= A
+            end
         end
     end
 


### PR DESCRIPTION
This improves performance in broadcasting operations, as the zero bands check may be skipped altogether.
On master
```julia
julia> A = brand(1000,1000, 2,2);

julia> B = brand(size(A)..., 1,1);

julia> @btime $A + $B;
  20.805 μs (3 allocations: 39.16 KiB)
```
This PR
```julia
julia> @btime $A + $B;
  16.539 μs (3 allocations: 39.16 KiB)
```
The difference comes entirely from the skipped `checkzerobands`