### PR TITLE
Use gbmv in banded*dense

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.21"
+version = "0.17.22"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -240,17 +240,21 @@ end
 ### BandedMatrix * dense matrix
 
 function materialize!(M::MulAdd{BandedColumns{DenseColumnMajor}, <:AbstractColumnMajor, <:AbstractColumnMajor,
-        T, <:AbstractMatrix, <:AbstractMatrix, <:AbstractMatrix}) where {T<:BlasFloat}
+        T, <:AbstractMatrix, <:AbstractMatrix, <:AbstractMatrix}) where {T}
     α, β, C = M.α, M.β, M.C
     A, B = Base.unalias(C, M.A), Base.unalias(C, M.B)
 
     mA, nA = size(A)
     mB, nB = size(B)
     mC, nC = size(C)
-    (nA == mB && mC == mA && nC == nB) || throw(DimensionMismatch("Dimensions must match"))
+    (nA == mB && mC == mA && nC == nB) || throw(DimensionMismatch("A has size ($mA, $nA), B has size ($mB, $nB), C has size ($mC, $nC)"))
 
-    for (colC, colB) in zip(eachcol(C), eachcol(B))
-        mul!(colC, A, colB, α, β)
+    if iszero(α)
+        lmul!(β, C)
+    else
+        for (colC, colB) in zip(eachcol(C), eachcol(B))
+            mul!(colC, A, colB, α, β)
+        end
     end
 
     return C

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -241,8 +241,7 @@ end
 
 function materialize!(M::MulAdd{BandedColumns{DenseColumnMajor}, <:AbstractColumnMajor, <:AbstractColumnMajor,
         T, <:AbstractMatrix, <:AbstractMatrix, <:AbstractMatrix}) where {T}
-    α, β, C = M.α, M.β, M.C
-    A, B = Base.unalias(C, M.A), Base.unalias(C, M.B)
+    α, β, A, B, C = M.α, M.β, M.A, M.B, M.C
 
     mA, nA = size(A)
     mB, nB = size(B)

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -239,7 +239,7 @@ end
 
 ### BandedMatrix * dense matrix
 
-function materialize!(M::MulAdd{BandedColumns{DenseColumnMajor}, DenseColumnMajor, DenseColumnMajor,
+function materialize!(M::MulAdd{BandedColumns{DenseColumnMajor}, <:AbstractColumnMajor, <:AbstractColumnMajor,
         T, <:AbstractMatrix, <:AbstractMatrix, <:AbstractMatrix}) where {T<:BlasFloat}
     α, β, C = M.α, M.β, M.C
     A, B = Base.unalias(C, M.A), Base.unalias(C, M.B)

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -244,6 +244,11 @@ function materialize!(M::MulAdd{BandedColumns{DenseColumnMajor}, DenseColumnMajo
     α, β, C = M.α, M.β, M.C
     A, B = Base.unalias(C, M.A), Base.unalias(C, M.B)
 
+    mA, nA = size(A)
+    mB, nB = size(B)
+    mC, nC = size(C)
+    (nA == mB && mC == mA && nC == nB) || throw(DimensionMismatch("Dimensions must match"))
+
     for (colC, colB) in zip(eachcol(C), eachcol(B))
         mul!(colC, A, colB, α, β)
     end

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -236,3 +236,17 @@ function materialize!(M::MatMulMatAdd{<:AbstractBandedLayout,<:DiagonalLayout{<:
     M.C .= (M.α * getindex_value(M.B.diag)) .* M.A .+ M.β .* M.C
     M.C
 end
+
+### BandedMatrix * dense matrix
+
+function materialize!(M::MulAdd{BandedColumns{DenseColumnMajor}, DenseColumnMajor, DenseColumnMajor,
+        T, <:AbstractMatrix, <:AbstractMatrix, <:AbstractMatrix}) where {T<:BlasFloat}
+    α, β, C = M.α, M.β, M.C
+    A, B = Base.unalias(C, M.A), Base.unalias(C, M.B)
+
+    for (colC, colB) in zip(eachcol(C), eachcol(B))
+        mul!(colC, A, colB, α, β)
+    end
+
+    return C
+end

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -46,8 +46,10 @@ import BandedMatrices: BandedColumns, _BandedMatrix
             cmp = T <: Integer ? (==) : (≈)
             B = BandedMatrix(Symmetric(BandedMatrix{T}(0=>1:10, 1=>11:19, 2=>21:28)))
             M = Matrix(B)
+
             _v = T[1:10;]
-            for v in Any[_v, view(_v, :), view(_v, axes(_v)...)]
+            _v2 = T[1:20;]
+            for v in Any[_v, view(_v, :), view(_v, axes(_v)...), view(_v2, axes(_v)...)]
                 Bv = M * _v
                 @test cmp(B * v, Bv)
                 w = similar(Bv)
@@ -65,8 +67,11 @@ import BandedMatrices: BandedColumns, _BandedMatrix
             end
 
             _X = reshape(T[1:100;], 10, 10)
+            _X2 = reshape(T[1:15^2;], 15, 15)
             for X in Any[_X, view(_X, :, :), view(_X, axes(_X)...), view(_X, :, axes(_X,2)), view(_X, axes(_X,1), :),
-                        _X', view(_X', :, :), view(_X', axes(_X')...)]
+                        view(_X2, axes(_X)...),
+                        _X', view(_X', :, :), view(_X', axes(_X')...),
+                        view(_X2', axes(_X)...)]
                 BX = M * X
                 @test cmp(B * X, BX)
                 Y = similar(BX)

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -86,13 +86,6 @@ import BandedMatrices: BandedColumns, _BandedMatrix
                 Y .= 1
                 mul!(Y, B, X, oneunit(T), oneunit(T))
                 @test cmp(Y, BX + ones(T, size(Y)))
-                # aliasing
-                X2 = copy(X)
-                mul!(X2, B, X2, true, true)
-                @test cmp(X2, BX + X)
-                X2 .= X
-                mul!(X2, B, X2, oneunit(T), oneunit(T))
-                @test cmp(X2, BX + X)
             end
         end
     end

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -47,8 +47,8 @@ import BandedMatrices: BandedColumns, _BandedMatrix
             B = brand(T, 10,10,2,2)
             M = Matrix(B)
             _v = T[1:10;]
-            Bv = M * _v
             for v in Any[_v, view(_v, :), view(_v, axes(_v)...)]
+                Bv = M * _v
                 @test cmp(B * v, Bv)
                 w = similar(Bv)
                 @test cmp(mul!(w, B, v), Bv)
@@ -59,8 +59,9 @@ import BandedMatrices: BandedColumns, _BandedMatrix
             end
 
             _X = reshape(T[1:100;], 10, 10)
-            BX = M * _X
-            for X in Any[_X, view(_X, :, :), view(_X, axes(_X)...), view(_X, :, axes(_X,2)), view(_X, axes(_X,1), :)]
+            for X in Any[_X, view(_X, :, :), view(_X, axes(_X)...), view(_X, :, axes(_X,2)), view(_X, axes(_X,1), :),
+                        _X', view(_X', :, :), view(_X', axes(_X')...)]
+                BX = M * X
                 @test cmp(B * X, BX)
                 Y = similar(BX)
                 @test cmp(mul!(Y, B, X), BX)

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -86,6 +86,13 @@ import BandedMatrices: BandedColumns, _BandedMatrix
                 Y .= 1
                 mul!(Y, B, X, oneunit(T), oneunit(T))
                 @test cmp(Y, BX + ones(T, size(Y)))
+                # aliasing
+                X2 = copy(X)
+                mul!(X2, B, X2, true, true)
+                @test cmp(X2, BX + X)
+                X2 .= X
+                mul!(X2, B, X2, oneunit(T), oneunit(T))
+                @test cmp(X2, BX + X)
             end
         end
     end

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -44,7 +44,7 @@ import BandedMatrices: BandedColumns, _BandedMatrix
     @testset "BandedMatrix * dense" begin
         @testset for T in [Float64, Int]
             cmp = T <: Integer ? (==) : (≈)
-            B = brand(T, 10,10,2,2)
+            B = BandedMatrix(Symmetric(BandedMatrix{T}(0=>1:10, 1=>11:19, 2=>21:28)))
             M = Matrix(B)
             _v = T[1:10;]
             for v in Any[_v, view(_v, :), view(_v, axes(_v)...)]

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -54,6 +54,12 @@ import BandedMatrices: BandedColumns, _BandedMatrix
                 @test cmp(mul!(w, B, v), Bv)
                 @test cmp(mul!(w, B, v, true, false), Bv)
                 w .= 1
+                mul!(w, B, v, true, true)
+                @test cmp(w, Bv + ones(T, size(w)))
+                w .= 2
+                mul!(w, B, v, false, true)
+                @test cmp(w, fill(T(2), size(w)))
+                w .= 1
                 mul!(w, B, v, oneunit(T), oneunit(T))
                 @test cmp(w, Bv + ones(T, size(w)))
             end
@@ -66,6 +72,12 @@ import BandedMatrices: BandedColumns, _BandedMatrix
                 Y = similar(BX)
                 @test cmp(mul!(Y, B, X), BX)
                 @test cmp(mul!(Y, B, X, true, false), BX)
+                Y .= 1
+                mul!(Y, B, X, true, true)
+                @test cmp(Y, BX + ones(T, size(Y)))
+                Y .= 2
+                mul!(Y, B, X, false, true)
+                @test cmp(Y, fill(T(2), size(Y)))
                 Y .= 1
                 mul!(Y, B, X, oneunit(T), oneunit(T))
                 @test cmp(Y, BX + ones(T, size(Y)))


### PR DESCRIPTION
This PR avoids hitting `default_blasmul` and uses `gbmv` in evaluating `B::BandedMartix * X::Matrix`, by looping over the columns. The approach is naive, but this is already significantly better than the fallback.

```julia
julia> B = brand(4000, 4000, 5, 5); X = rand(size(B)...);

julia> @btime $B * $X;
  970.386 ms (2 allocations: 122.07 MiB) # master
  161.312 ms (2 allocations: 122.07 MiB) # PR
```

This PR requires https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl/pull/131 to be merged first for optimal performance, otherwise the 5-argument matrix-vector `mul!` becomes very slow.

I've made the method very specific for now, but this may be relaxed along with more tests.