### PR TITLE
`unalias` in `_banded_gbmv!`

### DIFF
--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -32,7 +32,7 @@ banded_gbmv!(tA, α, A, x, β, y) =
     if length(x) == 0
         _fill_lmul!(β, y)
     else
-        xc = x ≡ y ? copy(x) : x
+        xc = Base.unalias(y, x)
         banded_gbmv!(tA, α, A, xc, β, y)
     end
     return y


### PR DESCRIPTION
This improves type-inference, and removes an allocation in `BandedMatrix * Vector`.

```julia
julia> B = brand(4000, 4000, 5, 5); v = rand(size(B,2)); w = copy(v);

julia> @btime ((v,B,w) -> mul!(view(w,:), B, view(v,:)))($v,$B,$w);
  23.250 μs (1 allocation: 48 bytes) # master
  23.238 μs (0 allocations: 0 bytes) # PR
```