### PR TITLE
Faster `getindex` for `BandedEigenvectors`

### DIFF
--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -7,12 +7,27 @@ struct BandedEigenvectors{T} <: AbstractMatrix{T}
 end
 
 size(B::BandedEigenvectors) = size(B.Q)
-function getindex(B::BandedEigenvectors{T}, i::Int, j::Int) where {T}
+getindex(B::BandedEigenvectors, i, j) = Matrix(B)[i,j]
+function _getindex_vec(B::BandedEigenvectors{T}, j) where {T}
     z1, z2 = B.z1, B.z2
     z2 .= zero(T)
     z2[j] = oneunit(T)
     mul!(z1, B, z2)
-    z1[i]
+end
+function getindex(B::BandedEigenvectors, i::Int, j::Int)
+    z = _getindex_vec(B, j)
+    z[i]
+end
+function getindex(B::BandedEigenvectors, ::Colon, j::Int)
+    z = _getindex_vec(B, j)
+    copy(z)
+end
+function getindex(B::BandedEigenvectors, ::Colon, jr::AbstractVector{<:Int})
+    M = similar(B, size(B,1), length(jr))
+    for (ind, j) in enumerate(jr)
+        M[:, ind] = _getindex_vec(B, j)
+    end
+    return M
 end
 
 # V = S⁻¹ Q W

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -7,7 +7,7 @@ struct BandedEigenvectors{T} <: AbstractMatrix{T}
 end
 
 size(B::BandedEigenvectors) = size(B.Q)
-function getindex(B::BandedEigenvectors{T}, i, j) where {T}
+function getindex(B::BandedEigenvectors{T}, i::Int, j::Int) where {T}
     z1, z2 = B.z1, B.z2
     z2 .= zero(T)
     z2[j] = oneunit(T)

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -96,7 +96,7 @@ function compress!(F::Eigen{T, T, BandedEigenvectors{T}, Vector{T}}) where T
     F
 end
 
-function mul!(y::AbstractArray{T,N}, B::BandedEigenvectors{T}, x::AbstractArray{T,N}) where {T,N}
+function mul!(y::Array{T,N}, B::BandedEigenvectors{T}, x::Array{T,N}) where {T,N}
     mul!(y, B.Q, x)
     G = B.G
     for k in length(G):-1:1
@@ -105,7 +105,7 @@ function mul!(y::AbstractArray{T,N}, B::BandedEigenvectors{T}, x::AbstractArray{
     y
 end
 
-function mul!(y::AbstractArray{T,N}, B::Adjoint{T,BandedEigenvectors{T}}, x::AbstractArray{T,N}) where {T,N}
+function mul!(y::Array{T,N}, B::Adjoint{T,BandedEigenvectors{T}}, x::Array{T,N}) where {T,N}
     Q = B.parent.Q
     G = B.parent.G
     if length(G) > 0
@@ -120,7 +120,7 @@ function mul!(y::AbstractArray{T,N}, B::Adjoint{T,BandedEigenvectors{T}}, x::Abs
     y
 end
 
-function mul!(y::AbstractArray{T,N}, B::Transpose{T,BandedEigenvectors{T}}, x::AbstractArray{T,N}) where {T,N}
+function mul!(y::Array{T,N}, B::Transpose{T,BandedEigenvectors{T}}, x::Array{T,N}) where {T,N}
     Q = B.parent.Q
     G = B.parent.G
     if length(G) > 0
@@ -135,7 +135,7 @@ function mul!(y::AbstractArray{T,N}, B::Transpose{T,BandedEigenvectors{T}}, x::A
     y
 end
 
-function mul!(y::AbstractArray{T,N}, B::BandedGeneralizedEigenvectors{T}, x::AbstractArray{T,N}) where {T,N}
+function mul!(y::Array{T,N}, B::BandedGeneralizedEigenvectors{T}, x::Array{T,N}) where {T,N}
     mul!(y, B.W, x)
     Q = B.Q
     for k in length(Q):-1:1
@@ -144,7 +144,7 @@ function mul!(y::AbstractArray{T,N}, B::BandedGeneralizedEigenvectors{T}, x::Abs
     ldiv!(B.S, y)
 end
 
-function mul!(y::AbstractArray{T,N}, B::Adjoint{T,BandedGeneralizedEigenvectors{T,M}}, x::AbstractArray{T,N}) where {T,M,N}
+function mul!(y::Array{T,N}, B::Adjoint{T,BandedGeneralizedEigenvectors{T,M}}, x::Array{T,N}) where {T,M,N}
     z = copy(x)
     ldiv!(B.parent.S', z)
     Q = B.parent.Q
@@ -154,7 +154,7 @@ function mul!(y::AbstractArray{T,N}, B::Adjoint{T,BandedGeneralizedEigenvectors{
     mul!(y, B.parent.W', z)
 end
 
-function ldiv!(y::AbstractArray{T,N}, B::BandedGeneralizedEigenvectors{T}, x::AbstractArray{T,N}) where {T,N}
+function ldiv!(y::Array{T,N}, B::BandedGeneralizedEigenvectors{T}, x::Array{T,N}) where {T,N}
     z = copy(x)
     lmul!(B.S, z)
     Q = B.Q
@@ -164,14 +164,14 @@ function ldiv!(y::AbstractArray{T,N}, B::BandedGeneralizedEigenvectors{T}, x::Ab
     mul!(y, B.W', z)
 end
 
-function mul!(y::AbstractArray{T,N}, x::AbstractArray{T,N}, B::BandedEigenvectors{T}) where {T,N}
+function mul!(y::Array{T,N}, x::Array{T,N}, B::BandedEigenvectors{T}) where {T,N}
     x .= x'
     mul!(y, B', x)
     x .= x'
     y .= y'
 end
 
-function mul!(y::AbstractArray{T,N}, x::AbstractArray{T,N}, B::BandedGeneralizedEigenvectors{T}) where {T,N}
+function mul!(y::Array{T,N}, x::Array{T,N}, B::BandedGeneralizedEigenvectors{T}) where {T,N}
     x .= x'
     mul!(y, B', x)
     x .= x'

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -73,6 +73,7 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     FD = convert(Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}}, F)
     @test FD.vectors'Matrix(A)*FD.vectors ≈ Diagonal(F.values)
 
+    @test Q[1,2] ≈ Matrix(Q)[1,2]
 
     function An(::Type{T}, N::Int) where {T}
         A = Symmetric(BandedMatrix(Zeros{T}(N,N), (0, 2)))

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -73,7 +73,11 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     FD = convert(Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}}, F)
     @test FD.vectors'Matrix(A)*FD.vectors ≈ Diagonal(F.values)
 
-    @test Q[1,2] ≈ Matrix(Q)[1,2]
+    MQ = Matrix(Q)
+    @test Q[axes(Q,1),1:3] ≈ MQ[axes(Q,1),1:3]
+    @test Q[:,1:3] ≈ MQ[:,1:3]
+    @test Q[:,3] ≈ MQ[:,3]
+    @test Q[1,2] ≈ MQ[1,2]
 
     function An(::Type{T}, N::Int) where {T}
         A = Symmetric(BandedMatrix(Zeros{T}(N,N), (0, 2)))


### PR DESCRIPTION
Fix https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/issues/346 by following the suggestion in https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/issues/346#issuecomment-1516543380, except the temporary vectors are stored in the struct to avoid reallocating them on every access. One of the vectors may be replaced by a `OneElement` after https://github.com/JuliaArrays/FillArrays.jl/pull/241 is merged.

After this,
```julia
julia> @time λ,Q = eigen(Symmetric(brand(1000, 1000, 4, 4)));
  0.199235 seconds (58 allocations: 27.075 MiB)

julia> @btime $Q[1,1];
  1.929 ms (0 allocations: 0 bytes)
```