### PR TITLE
`OneElement` in `getindex` for `BandedEigenvectors`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.22"
+version = "0.17.23"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -13,7 +13,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Aqua = "0.6"
 ArrayLayouts = "1"
 Documenter = "0.27"
-FillArrays = "1"
+FillArrays = "1.0.1"
 PrecompileTools = "1"
 julia = "1.6"
 

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -36,7 +36,7 @@ import ArrayLayouts: MemoryLayout, transposelayout, triangulardata,
                     _qr!, _qr, _lu!, _lu, _factorize, AbstractTridiagonalLayout, TridiagonalLayout,
                     BidiagonalLayout, bidiagonaluplo, diagonaldata, supdiagonaldata, subdiagonaldata
 
-import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_value
+import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_value, OneElement
 
 const libblas = Base.libblas_name
 const liblapack = Base.liblapack_name


### PR DESCRIPTION
This provides a slight improvement in performance and reduction in allocations on `FillArrays` v1.0.1 and above.

In https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/pull/354, we had
```julia
julia> @time λ,Q = eigen(Symmetric(brand(1000, 1000, 4, 4)));
  0.199235 seconds (58 allocations: 27.075 MiB)

julia> @btime $Q[1,1];
  1.929 ms (0 allocations: 0 bytes)
``` 

After this,
```julia
julia> @time λ,Q = eigen(Symmetric(brand(1000, 1000, 4, 4)));
  0.189025 seconds (58 allocations: 27.067 MiB)

julia> @btime $Q[1,1];
  1.462 ms (0 allocations: 0 bytes)
```