### PR TITLE
In-place eigvals for complex Hermitian `BandedMatrix`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.23"
+version = "0.17.24"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -115,6 +115,36 @@ for (fname, elty) in ((:dsbtrd_,:Float64),
     end
 end
 
+for (fname, elty) in ((:zhbtrd_,:ComplexF64),
+                      (:chbtrd_,:ComplexF32))
+    @eval begin
+        Relty = real($elty)
+        function hbtrd!(vect::Char, uplo::Char,
+                        m::Int, k::Int, A::AbstractMatrix{$elty},
+                        d::AbstractVector{Relty}, e::AbstractVector{Relty}, Q::AbstractMatrix{$elty},
+                        work::AbstractVector{$elty})
+            require_one_based_indexing(A)
+            chkstride1(A)
+            chkuplo(uplo)
+            chkvect(vect)
+            info = Ref{BlasInt}()
+            n    = size(A,2)
+            n ≠ m && throw(ArgumentError("Matrix must be square"))
+            size(A,1) < k+1 && throw(ArgumentError("Not enough bands"))
+            info  = Ref{BlasInt}()
+            ccall((@blasfunc($fname), liblapack), Nothing,
+                (Ref{UInt8}, Ref{UInt8},
+                 Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
+                 Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
+                 vect, uplo,
+                 n, k, A, max(1,stride(A,2)),
+                 d, e, Q, max(1,stride(Q,2)), work, info)
+            LAPACK.chklapackerror(info[])
+            d, e, Q
+        end
+    end
+end
+
 ## Bidiagonalization
 for (fname, elty) in ((:dgbbrd_,:Float64),
                       (:sgbbrd_,:Float32))

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -118,7 +118,7 @@ end
 for (fname, elty) in ((:zhbtrd_,:ComplexF64),
                       (:chbtrd_,:ComplexF32))
     @eval begin
-        Relty = real($elty)
+        local Relty = real($elty)
         function hbtrd!(vect::Char, uplo::Char,
                         m::Int, k::Int, A::AbstractMatrix{$elty},
                         d::AbstractVector{Relty}, e::AbstractVector{Relty}, Q::AbstractMatrix{$elty},
@@ -133,12 +133,33 @@ for (fname, elty) in ((:zhbtrd_,:ComplexF64),
             size(A,1) < k+1 && throw(ArgumentError("Not enough bands"))
             info  = Ref{BlasInt}()
             ccall((@blasfunc($fname), liblapack), Nothing,
-                (Ref{UInt8}, Ref{UInt8},
-                 Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
-                 Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
-                 vect, uplo,
-                 n, k, A, max(1,stride(A,2)),
-                 d, e, Q, max(1,stride(Q,2)), work, info)
+                (
+                    Ref{UInt8},
+                    Ref{UInt8},
+                    Ref{BlasInt},
+                    Ref{BlasInt},
+                    Ptr{$elty},
+                    Ref{BlasInt},
+                    Ptr{Relty},
+                    Ptr{Relty},
+                    Ptr{$elty},
+                    Ref{BlasInt},
+                    Ptr{$elty},
+                    Ptr{BlasInt},
+                ),
+                 vect,
+                 uplo,
+                 n,
+                 k,
+                 A,
+                 max(1,stride(A,2)),
+                 d,
+                 e,
+                 Q,
+                 max(1,stride(Q,2)),
+                 work,
+                 info
+            )
             LAPACK.chklapackerror(info[])
             d, e, Q
         end

--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -50,7 +50,7 @@ function eigen(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{
     eigen!(AA, copy(B))
 end
 
-function eigen!(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real
+function eigen!(A::HermOrSym{T,<:BandedMatrix{T}}) where T <: Real
     N = size(A, 1)
     KD = bandwidth(A)
     D = Vector{T}(undef, N)
@@ -61,6 +61,19 @@ function eigen!(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real
     sbtrd!('V', A.uplo, N, KD, AB, D, E, G, WORK)
     Λ, Q = eigen(SymTridiagonal(D, E))
     Eigen(Λ, BandedEigenvectors(G, Q, similar(Q, size(Q,1))))
+end
+
+function eigen!(A::Hermitian{T,<:BandedMatrix{T}}) where T <: Complex
+    N = size(A, 1)
+    KD = bandwidth(A)
+    D = Vector{real(T)}(undef, N)
+    E = Vector{real(T)}(undef, N-1)
+    Q = Matrix{T}(undef, N, N)
+    WORK = Vector{T}(undef, N)
+    AB = hermbandeddata(A)
+    hbtrd!('V', A.uplo, N, KD, AB, D, E, Q, WORK)
+    Λ, W = eigen(SymTridiagonal(D, E))
+    Eigen(Λ, Q * W)
 end
 
 function eigen!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{T}}) where T <: Real

--- a/src/symbanded/symbanded.jl
+++ b/src/symbanded/symbanded.jl
@@ -117,25 +117,13 @@ end
 
 ## eigvals routine
 
-
-function _tridiagonalize!(A::AbstractMatrix{T}, ::SymmetricLayout{<:BandedColumnMajor}) where T
-    n=size(A, 1)
-    d = Vector{T}(undef,n)
-    e = Vector{T}(undef,n-1)
-    Q = Matrix{T}(undef,0,0)
-    work = Vector{T}(undef,n)
-    sbtrd!('N', symmetricuplo(A), size(A,1), bandwidth(A), symbandeddata(A), d, e, Q, work)
-    SymTridiagonal(d,e)
-end
-
-tridiagonalize!(A::AbstractMatrix) = _tridiagonalize!(A, MemoryLayout(typeof(A)))
-
-eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T<:Base.IEEEFloat = eigvals!(copy(A))
+eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T<:Union{Float32, Float64} = eigvals!(copy(A))
 eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T<:Real = eigvals!(tridiagonalize(A))
 eigvals(A::Hermitian{T,<:BandedMatrix{T}}) where T<:Real = eigvals!(tridiagonalize(A))
 eigvals(A::Hermitian{T,<:BandedMatrix{T}}) where T<:Complex = eigvals!(tridiagonalize(A))
 
-eigvals!(A::Symmetric{T,<:BandedMatrix{T}}) where T <: Real = eigvals!(tridiagonalize!(A))
+eigvals!(A::HermOrSym{T,<:BandedMatrix{T}}) where T <: Real = eigvals!(tridiagonalize!(A))
+eigvals!(A::Hermitian{T,<:BandedMatrix{T}}) where T <: Complex = eigvals!(tridiagonalize!(A))
 function eigvals!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{T}}) where T<:Real
     n = size(A, 1)
     @assert n == size(B, 1)

--- a/src/symbanded/symbanded.jl
+++ b/src/symbanded/symbanded.jl
@@ -114,34 +114,6 @@ function materialize!(M::BlasMatMulVecAdd{<:HermitianLayout{<:BandedColumnMajor}
     _banded_hbmv!(symmetricuplo(A), α, A, x, β, y)
 end
 
-
-## eigvals routine
-
-eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T<:Union{Float32, Float64} = eigvals!(copy(A))
-eigvals(A::Symmetric{T,<:BandedMatrix{T}}) where T<:Real = eigvals!(tridiagonalize(A))
-eigvals(A::Hermitian{T,<:BandedMatrix{T}}) where T<:Real = eigvals!(tridiagonalize(A))
-eigvals(A::Hermitian{T,<:BandedMatrix{T}}) where T<:Complex = eigvals!(tridiagonalize(A))
-
-eigvals!(A::HermOrSym{T,<:BandedMatrix{T}}) where T <: Real = eigvals!(tridiagonalize!(A))
-eigvals!(A::Hermitian{T,<:BandedMatrix{T}}) where T <: Complex = eigvals!(tridiagonalize!(A))
-function eigvals!(A::Symmetric{T,<:BandedMatrix{T}}, B::Symmetric{T,<:BandedMatrix{T}}) where T<:Real
-    n = size(A, 1)
-    @assert n == size(B, 1)
-    @assert A.uplo == B.uplo
-    # compute split-Cholesky factorization of B.
-    kb = bandwidth(B)
-    B_data = symbandeddata(B)
-    pbstf!(B.uplo, n, kb, B_data)
-    # convert to a regular symmetric eigenvalue problem.
-    ka = bandwidth(A)
-    A_data = symbandeddata(A)
-    X = Array{T}(undef,0,0)
-    work = Vector{T}(undef,2n)
-    sbgst!('N', A.uplo, n, ka, kb, A_data, B_data, X, work)
-    # compute eigenvalues of symmetric eigenvalue problem.
-    eigvals!(A)
-end
-
 function copyto!(A::Symmetric{<:Number,<:BandedMatrix}, B::Symmetric{<:Number,<:BandedMatrix})
     size(A) == size(B) || throw(ArgumentError("sizes of A and B must match"))
     bandwidth(A) >= bandwidth(B) || throw(ArgumentError("bandwidth of A must exceed that of B"))

--- a/src/symbanded/tridiagonalize.jl
+++ b/src/symbanded/tridiagonalize.jl
@@ -84,3 +84,24 @@ function copybands(A::AbstractMatrix{T}, d::Integer) where T
     B
 end
 
+function _tridiagonalize!(A::AbstractMatrix{T}, ::SymmetricLayout{<:BandedColumnMajor}) where T<:Union{Float32,Float64}
+    n=size(A, 1)
+    d = Vector{T}(undef,n)
+    e = Vector{T}(undef,n-1)
+    Q = Matrix{T}(undef,0,0)
+    work = Vector{T}(undef,n)
+    sbtrd!('N', symmetricuplo(A), size(A,1), bandwidth(A), symbandeddata(A), d, e, Q, work)
+    SymTridiagonal(d,e)
+end
+
+function _tridiagonalize!(A::AbstractMatrix{T}, ::HermitianLayout{<:BandedColumnMajor}) where T<:Union{ComplexF32,ComplexF64}
+    n=size(A, 1)
+    d = Vector{real(T)}(undef,n)
+    e = Vector{real(T)}(undef,n-1)
+    Q = Matrix{T}(undef,0,0)
+    work = Vector{T}(undef,n)
+    hbtrd!('N', symmetricuplo(A), size(A,1), bandwidth(A), hermbandeddata(A), d, e, Q, work)
+    SymTridiagonal(d,e)
+end
+
+tridiagonalize!(A::AbstractMatrix) = _tridiagonalize!(A, MemoryLayout(typeof(A)))

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -47,13 +47,20 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     # (generalized) eigen & eigvals
     Random.seed!(0)
 
-    A = brand(Float64, 100, 100, 2, 4)
-    std = eigvals(Symmetric(Matrix(A)))
-    @test eigvals(Symmetric(A)) ≈ std
-    @test eigvals(Hermitian(A)) ≈ std
-    @test eigvals(Hermitian(big.(A))) ≈ std
+    for T in [Float32, Float64]
+        A = brand(T, 10, 10, 2, 4)
+        std = eigvals(Symmetric(Matrix(A)))
+        @test eigvals(Symmetric(A)) ≈ std
+        @test eigvals!(copy(Symmetric(A))) ≈ std
+        @test eigvals(Hermitian(A)) ≈ std
+        @test eigvals!(copy(Hermitian(A))) ≈ std
+        @test eigvals(Hermitian(big.(A))) ≈ std
 
-    A = brand(ComplexF64, 100, 100, 4, 0)
+        @test eigvals(Symmetric(A, :L)) ≈ eigvals(Symmetric(Matrix(A), :L))
+        @test eigvals(Hermitian(A, :L)) ≈ eigvals(Hermitian(Matrix(A), :L))
+    end
+
+    A = brand(ComplexF64, 20, 20, 4, 0)
     @test Symmetric(A)[2:10,1:9] isa BandedMatrix
     @test Hermitian(A)[2:10,1:9] isa BandedMatrix
     @test isempty(Hermitian(A)[1:0,1:9])
@@ -62,9 +69,13 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     @test [Symmetric(A)[k,j] for k=2:10, j=1:9] == Symmetric(A)[2:10,1:9]
     @test [Hermitian(A)[k,j] for k=2:10, j=1:9] == Hermitian(A)[2:10,1:9]
 
-    std = eigvals(Hermitian(Matrix(A), :L))
-    @test eigvals(Hermitian(A, :L)) ≈ std
-    @test eigvals(Hermitian(big.(A), :L)) ≈ std
+    for T in [ComplexF64, ComplexF32]
+        A = brand(T, 20, 20, 4, 2)
+        std = eigvals(Hermitian(Matrix(A), :L))
+        @test eigvals(Hermitian(A, :L)) ≈ std
+        @test eigvals(Hermitian(big.(A), :L)) ≈ std
+        @test eigvals!(copy(Hermitian(A, :L))) ≈ std
+    end
 
     A = Symmetric(brand(Float64, 100, 100, 2, 4))
     F = eigen(A)

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -76,6 +76,12 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     FD = convert(Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}}, F)
     @test FD.vectors'Matrix(A)*FD.vectors ≈ Diagonal(F.values)
 
+    MQ = Matrix(Q)
+    @test Q[axes(Q,1),1:3] ≈ MQ[axes(Q,1),1:3]
+    @test Q[:,1:3] ≈ MQ[:,1:3]
+    @test Q[:,3] ≈ MQ[:,3]
+    @test Q[1,2] ≈ MQ[1,2]
+
     F = eigen(A, 2:4)
     Λ, Q = F
     QM = Matrix(Q)
@@ -85,12 +91,6 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
     Λ, Q = F
     QM = Matrix(Q)
     @test QM' * (Matrix(A)*QM) ≈ Diagonal(Λ)
-
-    MQ = Matrix(Q)
-    @test Q[axes(Q,1),1:3] ≈ MQ[axes(Q,1),1:3]
-    @test Q[:,1:3] ≈ MQ[:,1:3]
-    @test Q[:,3] ≈ MQ[:,3]
-    @test Q[1,2] ≈ MQ[1,2]
 
     function An(::Type{T}, N::Int) where {T}
         A = Symmetric(BandedMatrix(Zeros{T}(N,N), (0, 2)))


### PR DESCRIPTION
After this,
```julia

julia> A = Hermitian(brand(ComplexF64, 6, 6, 2, 2))
6×6 Hermitian{ComplexF64, BandedMatrix{ComplexF64, Matrix{ComplexF64}, Base.OneTo{Int64}}}:
 0.539725+0.0im          0.25559+0.00579831im  0.559341+0.114413im            ⋅                      ⋅                      ⋅    
  0.25559-0.00579831im  0.784935+0.0im         0.378323+0.837163im   0.337384+0.392795im             ⋅                      ⋅    
 0.559341-0.114413im    0.378323-0.837163im    0.744348+0.0im        0.153074+0.0727464im   0.420417+0.0808449im            ⋅    
          ⋅             0.337384-0.392795im    0.153074-0.0727464im  0.267722+0.0im         0.377242+0.541864im    0.690377+0.470517im
          ⋅                      ⋅             0.420417-0.0808449im  0.377242-0.541864im     0.67322+0.0im        0.0208153+0.151669im
          ⋅                      ⋅                      ⋅            0.690377-0.470517im   0.0208153-0.151669im    0.850139+0.0im

julia> eigvals!(copy(A))
6-element Vector{Float64}:
 -0.8404525797103768
 -0.1783975827526587
  0.459438228060648
  0.7997670633406646
  1.4132897571114231
  2.2064446339423642

julia> eigen!(copy(A))
Eigen{ComplexF64, Float64, Matrix{ComplexF64}, Vector{Float64}}
values:
6-element Vector{Float64}:
 -0.8404525797103773
 -0.17839758275265893
  0.4594382280606475
  0.7997670633406677
  1.4132897571114234
  2.2064446339423593
vectors:
6×6 Matrix{ComplexF64}:
 -0.148603+0.0im        -0.425349+0.0im           0.749991+0.0im         0.287983+0.0im        -0.294169+0.0im       0.255028+0.0im
   0.10547-0.376109im   -0.157143-0.329141im     -0.383595-0.338108im    0.217697-0.218831im   -0.202174-0.142623im  0.448417+0.308796im
   0.33548+0.102147im    0.619659+0.0252785im    0.0926653+0.13952im    0.0500393+0.0875024im  -0.340514+0.136919im  0.507191-0.249498im
  0.206242+0.622302im   -0.254169-0.337529im   -0.00461372-0.041927im    -0.13238-0.072834im    0.449047-0.102082im   0.37728-0.112541im
 -0.392573-0.0638003im  0.0315878-0.0271654im    -0.107969-0.313205im    0.045246+0.761045im   0.0967334-0.195571im  0.201939-0.24638im
 -0.246861-0.231159im    0.328377+0.115492im      0.185982+0.0433029im   0.184487-0.416562im    0.416109-0.533607im  0.128546-0.214531im
```
