### PR TITLE
restrict Adjoint copy to v1.9+

### DIFF
--- a/src/generic/AbstractBandedMatrix.jl
+++ b/src/generic/AbstractBandedMatrix.jl
@@ -180,9 +180,11 @@ end
 
 
 ####
-# AdjOrTrans
+# AdjOrTrans
 ####
 
 bandwidths(A::AdjOrTrans{T,S}) where {T,S} = reverse(bandwidths(parent(A)))
-copy(A::Adjoint{T,<:AbstractBandedMatrix}) where T = copy(parent(A))'
-copy(A::Transpose{T,<:AbstractBandedMatrix}) where T = transpose(copy(parent(A)))
+if VERSION >= v"1.9"
+    copy(A::Adjoint{T,<:AbstractBandedMatrix}) where T = copy(parent(A))'
+    copy(A::Transpose{T,<:AbstractBandedMatrix}) where T = transpose(copy(parent(A)))
+end


### PR DESCRIPTION
This reverts #227 on older Julia versions, as `lu` doesn't seem to have methods defined for `Adjoint` on Julia v1.6