### PR TITLE
Fixes to mul for BandedEigenvectors

### DIFF
--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -165,10 +165,12 @@ const AdjTransStridedVecOrMat{T} = Union{AdjTransStridedVec{T}, AdjTransStridedM
 
 const OneElementVecOrMat{T} = Union{OneElement{T,1}, OneElement{T,2}}
 
+const AdjTransStridedOrOneElVecOrMat{T} = Union{AdjTransStridedVecOrMat{T}, OneElementVecOrMat{T}}
+
 _adjtransfn(::Transpose) = transpose
 _adjtransfn(::Adjoint) = adjoint
 
-function mul!(y::AdjTransStridedVecOrMat{T}, B::BandedEigenvectors{T}, x::Union{AdjTransStridedVecOrMat{T}, OneElementVecOrMat{T}}) where {T}
+function mul!(y::AdjTransStridedVecOrMat{T}, B::BandedEigenvectors{T}, x::AdjTransStridedOrOneElVecOrMat{T}) where {T}
     mul!(y, B.Q, x)
     G = B.G
     for k in length(G):-1:1
@@ -192,7 +194,7 @@ function mul!(y::AdjTransStridedVecOrMat{T}, B::AdjTrans{T,BandedEigenvectors{T}
     y
 end
 
-function mul!(y::AdjTransStridedVecOrMat{T}, B::BandedGeneralizedEigenvectors{T}, x::AdjTransStridedVecOrMat{T}) where {T}
+function mul!(y::AdjTransStridedVecOrMat{T}, B::BandedGeneralizedEigenvectors{T}, x::AdjTransStridedOrOneElVecOrMat{T}) where {T}
     mul!(y, B.W, x)
     Q = B.Q
     for k in length(Q):-1:1

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -84,11 +84,22 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
 
     F = eigen(A, 2:4)
     Λ, Q = F
-    @test Q' * Matrix(A) * Q ≈ Diagonal(Λ)
+    QM = Matrix(Q)
+    AM = Matrix(A)
+    @test Q' * AM * Q ≈ Diagonal(Λ)
+    # explicit mul tests
+    @test AM * Q ≈ AM * QM
+    @test transpose(Q) * AM ≈ transpose(QM) * AM
+    @test adjoint(Q) * AM ≈ adjoint(QM) * AM
 
     F = eigen(A, 1, 2)
     Λ, Q = F
-    @test Q' * Matrix(A) * Q ≈ Diagonal(Λ)
+    @test Q' * AM * Q ≈ Diagonal(Λ)
+
+    # contrived test with an empty Givens rotation vector
+    B = BandedMatrices.BandedEigenvectors(LinearAlgebra.Givens{Float64}[], rand(4,4), zeros(4))
+    x = rand(4)
+    @test B' * x ≈ Matrix(B)' * x
 
     function An(::Type{T}, N::Int) where {T}
         A = Symmetric(BandedMatrix(Zeros{T}(N,N), (0, 2)))

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -1,5 +1,11 @@
-using BandedMatrices, LinearAlgebra, ArrayLayouts, Random, Test, GenericLinearAlgebra
+using ArrayLayouts
+using BandedMatrices
 import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedColumns
+using FillArrays
+using GenericLinearAlgebra
+using LinearAlgebra
+using Random
+using Test
 
 @testset "Symmetric" begin
     A = Symmetric(brand(10,10,1,2))
@@ -143,6 +149,9 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
         @test V * AM ≈ VM * AM
         x = rand(T, size(V,2))
         @test ldiv!(similar(x), V, x) ≈ ldiv!(similar(x), factorize(VM), x)
+
+        z = OneElement{T}(4, size(V,2))
+        @test V * z ≈ V * Vector(z)
     end
 
     @testset "eigen with mismatched parent bandwidths" begin

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -84,13 +84,11 @@ import BandedMatrices: MemoryLayout, SymmetricLayout, HermitianLayout, BandedCol
 
     F = eigen(A, 2:4)
     Λ, Q = F
-    QM = Matrix(Q)
-    @test QM' * (Matrix(A)*QM) ≈ Diagonal(Λ)
+    @test Q' * Matrix(A) * Q ≈ Diagonal(Λ)
 
     F = eigen(A, 1, 2)
     Λ, Q = F
-    QM = Matrix(Q)
-    @test QM' * (Matrix(A)*QM) ≈ Diagonal(Λ)
+    @test Q' * Matrix(A) * Q ≈ Diagonal(Λ)
 
     function An(::Type{T}, N::Int) where {T}
         A = Symmetric(BandedMatrix(Zeros{T}(N,N), (0, 2)))


### PR DESCRIPTION
Fix the multiplication `Matrix(A)*Q` in
```julia
julia> A = Symmetric(brand(Float64, 5, 5, 2, 4));

julia> F = eigen(A, 2:4);

julia> Λ, Q = F;

julia> Matrix(A) * Q
ERROR: DimensionMismatch: A has size (3,10), B has size (10,10), C has size (10, 3)
```
This PR
```julia
julia> Matrix(A) * Q
5×3 Matrix{Float64}:
 -0.215735   -0.0048621   0.543025
  0.481573    0.0179861   0.0938919
 -0.1956      0.093253   -0.308269
 -0.0523172  -0.198675   -0.19431
 -0.0175463   0.106258   -0.0838154
```