### PR TITLE
Faster indexing for `BandedGeneralizedEigenvectors`

### DIFF
--- a/src/symbanded/bandedeigen.jl
+++ b/src/symbanded/bandedeigen.jl
@@ -37,15 +37,11 @@ function _getindex_vec(B, j)
     z2 = OneElement(one(eltype(B)), j, size(B,2))
     mul!(z1, B, z2)
 end
-function getindex(B::AbstractBandedEigenvectors, i::Int, j::Int)
+function getindex(B::AbstractBandedEigenvectors, i::Union{Int, Colon, AbstractVector{Int}}, j::Int)
     z = _getindex_vec(B, j)
     z[i]
 end
-function getindex(B::AbstractBandedEigenvectors, ::Colon, j::Int)
-    z = _getindex_vec(B, j)
-    copy(z)
-end
-function getindex(B::AbstractBandedEigenvectors, ::Colon, jr::AbstractVector{<:Int})
+function getindex(B::AbstractBandedEigenvectors, ::Colon, jr::AbstractVector{Int})
     M = similar(B, size(B,1), length(jr))
     for (ind, j) in enumerate(jr)
         M[:, ind] = _getindex_vec(B, j)

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -143,15 +143,24 @@ using Test
         @test V'AM*V ≈ Diagonal(Λ)
         @test V'Matrix(B)*V ≈ I
 
-        # misc mul/div tests
         VM = Matrix(V)
-        @test AM * V ≈ AM * VM
-        @test V * AM ≈ VM * AM
-        x = rand(T, size(V,2))
-        @test ldiv!(similar(x), V, x) ≈ ldiv!(similar(x), factorize(VM), x)
 
-        z = OneElement{T}(4, size(V,2))
-        @test V * z ≈ V * Vector(z)
+        @testset "indexing" begin
+            @test V[axes(V,1),1:3] ≈ VM[axes(V,1),1:3]
+            @test V[:,1:3] ≈ VM[:,1:3]
+            @test V[:,3] ≈ VM[:,3]
+            @test V[1,2] ≈ VM[1,2]
+        end
+
+        @testset "mul/div" begin
+            @test AM * V ≈ AM * VM
+            @test V * AM ≈ VM * AM
+            x = rand(T, size(V,2))
+            @test ldiv!(similar(x), V, x) ≈ ldiv!(similar(x), factorize(VM), x)
+
+            z = OneElement{T}(4, size(V,2))
+            @test V * z ≈ V * Vector(z)
+        end
     end
 
     @testset "eigen with mismatched parent bandwidths" begin

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -149,6 +149,7 @@ using Test
             @test V[axes(V,1),1:3] ≈ VM[axes(V,1),1:3]
             @test V[:,1:3] ≈ VM[:,1:3]
             @test V[:,3] ≈ VM[:,3]
+            @test V[axes(V,1),3] ≈ VM[axes(V,1),3]
             @test V[1,2] ≈ VM[1,2]
         end
 


### PR DESCRIPTION
Similar to https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/pull/354. This PR introduces an abstract type `AbstractBandedEigenvectors` and defines the indexing for that, so that its subtypes `BandedEigenvectors` and `BandedGeneralizedEigenvectors` may share the behavior. A `BandedGeneralizedEigenvectors` may reuse the scratch vector in the enclosed `BandedEigenvectors`, so no extra allocation is necessary.

After this,
```julia
julia> A = Symmetric(brand(Float64, 6, 6, 2, 4));

julia> B = Symmetric(BandedMatrix(0=>Float64.(1:6)));

julia> Λ, V = eigen(A, B);

julia> @btime $V[1,1];
  96.803 ns (0 allocations: 0 bytes)
```
whereas, on master,
```julia
julia> @btime $V[1,1];
  377.146 ns (1 allocation: 368 bytes)
```