### PR TITLE
broadcast value to an entire band

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.24"
+version = "0.17.25"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -479,5 +479,21 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
         A[1:2:end,1:2:end] = X1
         @test A == B
     end
+
+    @testset "broadcasting to a band" begin
+        B = brand(Int8, 6, 6, -2, 2)
+        B[band(2)] .= 10
+        @test all(==(10), diag(B, 2))
+        @test all(==(10), B[band(2)])
+
+        B = brand(Int8, 2, 4, 1, 1)
+        B[band(-1)] .= 2
+        B[band(0)] .= 3
+        B[band(1)] .= 4
+        @test B == [3 4 0 0; 2 3 4 0]
+
+        @test_throws BandError B[band(100)] .= 10
+        @test_throws BandError B[band(-100)] .= 10
+    end
 end
 


### PR DESCRIPTION
Forwarding the broadcasting to the data matrix makes it much more efficient:

```julia
julia> B = brand(Int8, 200, 200, -2, 2);

julia> @btime $B[band(2)] .= 3;
  83.740 ns (0 allocations: 0 bytes) # PR
  1.223 μs (0 allocations: 0 bytes) # master
```