### PR TITLE
Broadcast a vector to a band

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.25"
+version = "0.17.26"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -471,7 +471,7 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
     end
 
     @testset "setindex! with ranges (#348)" begin
-        n = 10; 
+        n = 10;
         X1 = brand(n,n,1,1)
         B = BandedMatrix(Zeros(2n,2n), (3,3))
         B[1:2:end,1:2:end] = X1
@@ -480,20 +480,15 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
         @test A == B
     end
 
-    @testset "broadcasting to a band" begin
-        B = brand(Int8, 6, 6, -2, 2)
-        B[band(2)] .= 10
-        @test all(==(10), diag(B, 2))
-        @test all(==(10), B[band(2)])
-
-        B = brand(Int8, 2, 4, 1, 1)
-        B[band(-1)] .= 2
-        B[band(0)] .= 3
-        B[band(1)] .= 4
-        @test B == [3 4 0 0; 2 3 4 0]
-
-        @test_throws BandError B[band(100)] .= 10
-        @test_throws BandError B[band(-100)] .= 10
+    @testset "copy band to offset vector" begin
+        B = BandedMatrix(2=>2:3)
+        # test that a BandedMatrix and a Matrix behave identically
+        for M in (B, Matrix(B))
+            p = zeros(3)
+            v = view(p, Base.IdentityUnitRange(2:3))
+            copyto!(v, diag(M, 2))
+            @test p[1] == 0
+            @test p[2:3] == 2:3
+        end
     end
 end
-

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -483,12 +483,16 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
     @testset "copy band to offset vector" begin
         B = BandedMatrix(2=>2:3)
         # test that a BandedMatrix and a Matrix behave identically
+        p = zeros(3)
+        v = view(p, Base.IdentityUnitRange(2:3))
         for M in (B, Matrix(B))
-            p = zeros(3)
-            v = view(p, Base.IdentityUnitRange(2:3))
+            p .= 0
             copyto!(v, diag(M, 2))
             @test p[1] == 0
-            @test p[2:3] == 2:3
+            @test @view(p[2:3]) == 2:3
+            copyto!(v, diag(M, 10))
+            @test p[1] == 0
+            @test @view(p[2:3]) == 2:3
         end
     end
 end

--- a/test/test_broadcasting.jl
+++ b/test/test_broadcasting.jl
@@ -729,4 +729,30 @@ import BandedMatrices: BandedStyle, BandedRows, BandError
         @test Z .* A ≡ Z
         @test A .* Z ≡ Z
     end
+
+    @testset "broadcasting to a band" begin
+        B = brand(Int8, 6, 6, -2, 2)
+        B[band(2)] .= 10
+        @test all(==(10), diag(B, 2))
+        @test all(==(10), B[band(2)])
+
+        B = brand(Int8, 2, 4, 1, 1)
+        B[band(-1)] .= 2
+        B[band(0)] .= 3
+        B[band(1)] .= 4
+        B[band(2)] .= 0
+        @test B == [3 4 0 0; 2 3 4 0]
+
+        B[band(-1)] .= 3:3
+        @test all(==(3), @view B[band(-1)])
+        B[band(0)] .= 4:5
+        @test (@view B[band(0)]) == 4:5
+        B[band(1)] .= 3:4
+        @test (@view B[band(1)]) == 3:4
+        B[band(2)] .= [0,0]
+        @test all(iszero, @view B[band(2)])
+
+        @test_throws BandError B[band(100)] .= 10
+        @test_throws BandError B[band(-100)] .= 10
+    end
 end


### PR DESCRIPTION
After this PR
```julia
julia> B = brand(Int, 200, 200, 20, 20);

julia> @btime $B[band(2)] .= 1:198;
  204.381 ns (0 allocations: 0 bytes) # PR (improvement because of copyto implementation)
  978.750 ns (0 allocations: 0 bytes) # master

julia> @btime $B[band(2)] = 1:198;
  117.487 ns (0 allocations: 0 bytes) # PR (improvement becasue of inbounds)
  152.594 ns (0 allocations: 0 bytes) # master
```
Also, ensures that `setindex!` returns the array and not the value. This matches the `Base` behaviour.
```julia
julia> setindex!(zeros(2,2), 1, 1)
2×2 Matrix{Float64}:
 1.0  0.0
 0.0  0.0

julia> setindex!(fill!(brand(Float64,2,2,1,1),0), 1, 1)
2×2 BandedMatrix{Float64} with bandwidths (1, 1):
 1.0  0.0
 0.0  0.0
```