### PR TITLE
Extend getindex without Base namespace consistently

### DIFF
--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -447,7 +447,7 @@ function dataview(V::BandedMatrixBand)
     view(A.data, A.u - b + 1, max(b,0)+1:min(n,m+b))
 end
 
-@propagate_inbounds function Base.getindex(B::BandedMatrixBand, i::Int)
+@propagate_inbounds function getindex(B::BandedMatrixBand, i::Int)
     A = parent(parent(B))
     b = band(B)
     if -A.l ≤ band(B) ≤ A.u


### PR DESCRIPTION
Replace `Base.getindex` with `getindex`, which makes it easy to search for this