### PR TITLE
optimized setindex methods

### DIFF
--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -145,7 +145,7 @@ function checkbandmatch(A::AbstractMatrix{T}, V::AbstractVector, k::Integer, ::C
             throw(BandError(A, (k,j)))
         end
     end
-    for j = rowstop(A,j)+1:size(A,2)
+    for j = rowstop(A,k)+1:size(A,2)
         if V[j] ≠ zero(T)
             throw(BandError(A, (k,j)))
         end


### PR DESCRIPTION
```julia
julia> B = brand(Int, 200, 200, 20, 20);

julia> @btime $B[1,BandRange] = 1:21;
  29.909 ns (0 allocations: 0 bytes) # PR
  62.717 ns (0 allocations: 0 bytes) # master

julia> @btime $B[BandRange,1] = 1:21;
  34.899 ns (0 allocations: 0 bytes) # PR
  57.282 ns (0 allocations: 0 bytes) # master
```
The improvements are mainly due to fewer checks. The performances are identical if `@inbounds` is specified.