### PR TITLE
`@propagate_inbounds` in indexing a `BandSlice`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.28"
+version = "0.17.29"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -211,7 +211,7 @@ for f in (:indices, :unsafe_indices, :axes1, :first, :last, :size, :length,
     @eval $f(S::BandSlice) = $f(S.indices)
 end
 
-getindex(S::BandSlice, i::Union{Int, AbstractRange}) = getindex(S.indices, i)
+@propagate_inbounds getindex(S::BandSlice, i::Union{Int, AbstractRange}) = getindex(S.indices, i)
 show(io::IO, r::BandSlice) = print(io, "BandSlice(", r.band, ", ", r.indices, ")")
 
 to_index(::Band) = throw(ArgumentError("Block must be converted by to_indices(...)"))


### PR DESCRIPTION
On master
```julia
julia> A = zeros(10,10);

julia> r = first(to_indices(A, (band(1),)));

julia> @btime @inbounds $r[1:end];
  19.346 ns (0 allocations: 0 bytes)
```
After this PR,
```julia
julia> @btime @inbounds $r[1:end];
  13.774 ns (0 allocations: 0 bytes)
```