### PR TITLE
don't precompile for Float32/ComplexF32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.31"
+version = "0.17.32"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,7 @@
 using PrecompileTools
 
 @setup_workload begin
-	vs = ([1.0], Float32[1.0], ComplexF32[1.0], ComplexF64[1.0])
+	vs = ([1.0], ComplexF64[1.0])
 	Bs = Any[BandedMatrix(0 => v) for v in vs]
 	@compile_workload begin
 		for B in Bs, op in (+, -, *)


### PR DESCRIPTION
Given that 32-bit CPU arrays are perhaps not widely used at present, it's unnecessary to precompile and cache code for this case. Not doing so would shave off 0.15s from the package load time.