### PR TITLE
Use `LinearAlgebra.BLAS.libblas`

### DIFF
--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -36,8 +36,8 @@ import ArrayLayouts: MemoryLayout, transposelayout, triangulardata,
 
 import FillArrays: AbstractFill, getindex_value, _broadcasted_zeros, unique_value, OneElement
 
-const libblas = Base.libblas_name
-const liblapack = Base.liblapack_name
+const libblas = LinearAlgebra.BLAS.libblas
+const liblapack = LinearAlgebra.BLAS.liblapack
 const AdjointFact = isdefined(LinearAlgebra, :AdjointFactorization) ?
     LinearAlgebra.AdjointFactorization :
     Adjoint


### PR DESCRIPTION
The `Base.libblas_name` bindings have been deprecated for a long time, don't use those.