### PR TITLE
Don't throw in cholesky if check=false

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.34"
+version = "0.17.35"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -263,7 +263,7 @@ for (fname, elty) in ((:dpbtrf_,:Float64),
                  Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt}),
                  uplo, n, kd,
                  A, max(1,stride(A,2)), info)
-            LAPACK.chklapackerror(info[])
+            LAPACK.chkargsok(info[])
             A, info[]
         end
     end

--- a/test/test_symbanded.jl
+++ b/test/test_symbanded.jl
@@ -8,6 +8,20 @@ using Random
 using Test
 
 @testset "Symmetric" begin
+    @testset "UnitRange" begin
+        A = brand(100,100,3,2)
+        S = Symmetric(A)
+        @test S[3:10,4:11] == Symmetric(Matrix(A))[3:10,4:11]
+    end
+
+    @testset "Sym of degenerate bands" begin
+        A = SymTridiagonal(zeros(8), fill(0.5,7))
+        B = Symmetric(BandedMatrix(1 => fill(0.5,7)))
+        @test A ≈ B
+        @test BandedMatrices.inbands_getindex(B, 1, 1) == 0
+        @test BandedMatrices.inbands_getindex(B, 1, 2) == BandedMatrices.inbands_getindex(B, 2, 1) == 0.5
+    end
+
     A = Symmetric(brand(10,10,1,2))
     @test isbanded(A)
     @test BandedMatrix(A) == A
@@ -382,17 +396,8 @@ end
         VERSION >= v"1.9-" && @test Ac\b ≈ A\b
     end
 
-    @testset "UnitRange" begin
-        A = brand(100,100,3,2)
-        S = Symmetric(A)
-        @test S[3:10,4:11] == Symmetric(Matrix(A))[3:10,4:11]
-    end
-
-    @testset "Sym of degenerate bands" begin
-        A = SymTridiagonal(zeros(8), fill(0.5,7))
-        B = Symmetric(BandedMatrix(1 => fill(0.5,7)))
-        @test A ≈ B
-        @test BandedMatrices.inbands_getindex(B, 1, 1) == 0
-        @test BandedMatrices.inbands_getindex(B, 1, 2) == BandedMatrices.inbands_getindex(B, 2, 1) == 0.5
-    end
+    B = BandedMatrix(1=>Float64[1:4;], 0=>Float64[1:5;], -1=>Float64[1:4;])
+    @test isposdef(B) == isposdef(Matrix(B)) == false
+    B = BandedMatrix(1=>Float64[1:4;], 0=>Float64[2:2:10;], -1=>Float64[1:4;])
+    @test isposdef(B) == isposdef(Matrix(B)) == true
 end

--- a/test/test_tribanded.jl
+++ b/test/test_tribanded.jl
@@ -18,7 +18,7 @@ import BandedMatrices: BandedColumns, BandedRows
             x=rand(10)
             @test A*x ≈ BandedMatrix(A)*x ≈ Matrix(A)*x
             @test transpose(A)*x ≈ transpose(BandedMatrix(A))*x ≈ transpose(Matrix(A))*x
-            @test all(A*x .=== lmul!(A, copy(x)) .=== lmul(A,x) .===
+            @test all(A*x .≈ lmul!(A, copy(x)) .=== lmul(A,x) .===
                         BandedMatrices.tbmv!('U', 'N', ud, 10, 2, parent(A).data, copy(x)))
             @test_throws DimensionMismatch BandedMatrices.tbmv('U', 'N', ud, 10, 2, parent(A).data, rand(9))
 
@@ -44,7 +44,7 @@ import BandedMatrices: BandedColumns, BandedRows
             x=rand(10)
             @test A*x ≈ Matrix(A)*x
             @test transpose(A)*x ≈ transpose(BandedMatrix(A))*x ≈ transpose(Matrix(A))*x
-            @test all(A*x .=== lmul!(A, copy(x)) .=== lmul(A,x) .===
+            @test all(A*x .≈ lmul!(A, copy(x)) .=== lmul(A,x) .===
                         BandedMatrices.tbmv!('L', 'N', ud, 10, 1, view(parent(A).data, 3:4,:), copy(x)))
             @test_throws DimensionMismatch BandedMatrices.tbmv('L', 'N', ud, 10, 1, view(parent(A).data, 3:4,:), rand(9))
 


### PR DESCRIPTION
Fix https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl/issues/100

This mirrors the behavior in `LinearAlgebra`, and after this, the following are consistent:
```julia
julia> B = BandedMatrix(-3=> 2ones(2), -1=>ones(4), 0=>2ones(5)); Buplo = :L; SB = Symmetric(B, Buplo);

julia> cholesky(Matrix(SB), check = false)
Failed factorization of type Cholesky{Float64, Matrix{Float64}}

julia> cholesky(SB, check = false)
Failed factorization of type Cholesky{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}}
```