### PR TITLE
Fix 5-term mul with non-zero beta

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "0.17.36"
+version = "0.17.37"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -1,6 +1,10 @@
-using BandedMatrices, FillArrays, Test, LinearAlgebra, SparseArrays
+using ArrayLayouts
+using BandedMatrices
 import BandedMatrices: _BandedMatrix
-
+using FillArrays
+using LinearAlgebra
+using SparseArrays
+using Test
 
 # used to test general matrix backends
 struct MyMatrix{T} <: AbstractMatrix{T}

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -107,22 +107,31 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
     @testset "BandedMatrix * Vector" begin
         let A=brand(10,12,2,3), v=rand(12), w=rand(10)
             @test A*v ≈ Matrix(A)*v
+            # the left-side uses BLAS, while the right doesn't
+            @test mul!(ones(size(A,1)), A, v, 1.0, 2.0) ≈ mul!(ones(size(A,1)), A, v, 1, 2)
             @test A'*w ≈ Matrix(A)'*w
+            @test mul!(ones(size(A,2)), A', w, 1.0, 2.0) ≈ mul!(ones(size(A,2)), A', w, 1, 2)
         end
 
         let A=brand(Float64,5,3,2,2), v=rand(ComplexF64,3), w=rand(ComplexF64,5)
             @test A*v ≈ Matrix(A)*v
+            @test mul!(ones(ComplexF64,size(A,1)), A, v, 1.0, 2.0) ≈ mul!(ones(ComplexF64,size(A,1)), A, v, 1, 2)
             @test A'*w ≈ Matrix(A)'*w
+            @test mul!(ones(ComplexF64,size(A,2)), A', w, 1.0, 2.0) ≈ mul!(ones(ComplexF64,size(A,2)), A', w, 1, 2)
         end
 
         let A=brand(ComplexF64,5,3,2,2), v=rand(ComplexF64,3), w=rand(ComplexF64,5)
             @test A*v ≈ Matrix(A)*v
+            @test mul!(ones(ComplexF64,size(A,1)), A, v, 1.0, 2.0) ≈ mul!(ones(ComplexF64,size(A,1)), A, v, 1, 2)
             @test A'*w ≈ Matrix(A)'*w
+            @test mul!(ones(ComplexF64,size(A,2)), A', w, 1.0, 2.0) ≈ mul!(ones(ComplexF64,size(A,2)), A', w, 1, 2)
         end
 
         let A=brand(ComplexF64,5,3,2,2), v=rand(Float64,3), w=rand(Float64,5)
             @test A*v ≈ Matrix(A)*v
+            @test mul!(ones(ComplexF64,size(A,1)), A, v, 1.0, 2.0) ≈ mul!(ones(ComplexF64,size(A,1)), A, v, 1, 2)
             @test A'*w ≈ Matrix(A)'*w
+            @test mul!(ones(ComplexF64,size(A,2)), A', w, 1.0, 2.0) ≈ mul!(ones(ComplexF64,size(A,2)), A', w, 1, 2)
         end
 
         @testset "empty" begin

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -105,12 +105,17 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
     end
 
     @testset "BandedMatrix * Vector" begin
-        let A=brand(10,12,2,3), v=rand(12), w=rand(10)
-            @test A*v ≈ Matrix(A)*v
-            # the left-side uses BLAS, while the right doesn't
-            @test mul!(ones(size(A,1)), A, v, 1.0, 2.0) ≈ mul!(ones(size(A,1)), A, v, 1, 2)
-            @test A'*w ≈ Matrix(A)'*w
-            @test mul!(ones(size(A,2)), A', w, 1.0, 2.0) ≈ mul!(ones(size(A,2)), A', w, 1, 2)
+        let v=rand(12), w=rand(10)
+            for (l,u) in ((2,3), (-2,2), (2,-2), (2,-3))
+                A=brand(length(w),length(v),l,u)
+                @test A*v ≈ Matrix(A)*v
+                # the left-side uses BLAS, while the right doesn't
+                @test mul!(ones(size(A,1)), A, v, 1.0, 2.0) ≈ mul!(ones(size(A,1)), A, v, 1, 2)
+                @test A'*w ≈ Matrix(A)'*w
+                @test mul!(ones(size(A,2)), A', w, 1.0, 2.0) ≈ mul!(ones(size(A,2)), A', w, 1, 2)
+                # explicitly test materialize!
+                @test materialize!(MulAdd(1.0, A', w, 2.0, ones(size(A,2)))) ≈ materialize!(MulAdd(1, A', w, 2, ones(size(A,2))))
+            end
         end
 
         let A=brand(Float64,5,3,2,2), v=rand(ComplexF64,3), w=rand(ComplexF64,5)


### PR DESCRIPTION
Certain elements of `y` were being set to zero under the incorrect assumption that `beta=0`

Also, consistently perform size-compatibility checks in `materialize!` using `checkdimensions`