### PR TITLE
show for BandedMatrix may print the constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -956,3 +956,15 @@ function banded_axpy!(a::Number, X::BandedMatrix, Y::BandedMatrix)
     end
     return Y
 end
+
+# show
+function show(io::IO, B::BandedMatrix)
+    print(io, "BandedMatrix(")
+    l, u = bandwidths(B)
+    for (ind, b) in enumerate(-l:u)
+        r = @view B[band(b)]
+        show(io, b => r)
+        b == u || print(io, ", ")
+    end
+    print(io, ")")
+end

--- a/test/test_miscs.jl
+++ b/test/test_miscs.jl
@@ -89,6 +89,9 @@ import BandedMatrices: _BandedMatrix, DefaultBandedMatrix
         @test occursin(needle, sprint() do io
              show(io, MIME"text/plain"(), BandedMatrix(Eye(3),(1,1)))
           end)
+        B = BandedMatrix(-1=>[1:10;], 0=>[1:11;], 1=>[1:10;])
+        Bshowstr = sprint(show, B)
+        @test Bshowstr == "BandedMatrix($(-1=>[1:10;]), $(0=>[1:11;]), $(1=>[1:10;]))"
     end
     @time @testset "Issue #27" begin
         A=brand(1,10,0,9)

--- a/test/test_miscs.jl
+++ b/test/test_miscs.jl
@@ -89,9 +89,9 @@ import BandedMatrices: _BandedMatrix, DefaultBandedMatrix
         @test occursin(needle, sprint() do io
              show(io, MIME"text/plain"(), BandedMatrix(Eye(3),(1,1)))
           end)
-        B = BandedMatrix(-1=>[1:10;], 0=>[1:11;], 1=>[1:10;])
+        B = BandedMatrix(-1=>1:4, 0=>1:5, 1=>1:4)
         Bshowstr = sprint(show, B)
-        @test Bshowstr == "BandedMatrix($(-1=>[1:10;]), $(0=>[1:11;]), $(1=>[1:10;]))"
+        @test Bshowstr == "BandedMatrix($(-1=>[1:4;]), $(0=>[1:5;]), $(1=>[1:4;]))"
     end
     @time @testset "Issue #27" begin
         A=brand(1,10,0,9)


### PR DESCRIPTION
After this PR
```julia
julia> B = BandedMatrix(-1=>1:4, 0=>1:5, 1=>1:4);

julia> show(B)
BandedMatrix(-1 => [1, 2, 3, 4], 0 => [1, 2, 3, 4, 5], 1 => [1, 2, 3, 4])
```
vs on master
```julia
julia> show(B)
[1 1 0 0 0; 1 2 2 0 0; 0 2 3 3 0; 0 0 3 4 4; 0 0 0 4 5]
```
The new display format is more informative, sparse and a valid constructor as well.