### PR TITLE
Band views of SubArrays of BandedMatrices

### DIFF
--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -510,6 +510,7 @@ end
     if -l ≤ band(B) ≤ u
         dataview(B)[i]
     else
+        @boundscheck checkbounds(B, i)
         zero(eltype(B))
     end
 end

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -456,7 +456,9 @@ julia> view(B, band(0)) isa BandedMatrices.BandedMatrixBand
 true
 ```
 """
-const BandedMatrixBand{T} = SubArray{T, 1, <:ReshapedArray{T,1,<:BandedMatrix{T}}, Tuple{BandSlice}}
+const BandedMatrixBand{T} = SubArray{T, 1, <:ReshapedArray{T,1,
+                                <:Union{BandedMatrix{T}, SubArray{T,2,<:BandedMatrix{T},
+                                <:NTuple{2, AbstractUnitRange{Int}}}}}, Tuple{BandSlice}}
 
 
 band(V::BandedMatrixBand) = first(parentindices(V)).band.i
@@ -497,13 +499,15 @@ function dataview(V::BandedMatrixBand)
     A = parent(parent(V))
     b = band(V)
     m,n = size(A)
-    view(A.data, A.u - b + 1, max(b,0)+1:min(n,m+b))
+    u = bandwidth(A,2)
+    view(bandeddata(A), u - b + 1, max(b,0)+1:min(n,m+b))
 end
 
 @propagate_inbounds function getindex(B::BandedMatrixBand, i::Int)
     A = parent(parent(B))
     b = band(B)
-    if -A.l ≤ band(B) ≤ A.u
+    l, u = bandwidths(A)
+    if -l ≤ band(B) ≤ u
         dataview(B)[i]
     else
         zero(eltype(B))
@@ -513,7 +517,8 @@ end
 # B[band(i)]
 @inline function copyto!(v::AbstractVector, B::BandedMatrixBand)
     A = parent(parent(B))
-    if -A.l ≤ band(B) ≤ A.u
+    l, u = bandwidths(A)
+    if -l ≤ band(B) ≤ u
         copyto!(v, dataview(B))
     else
         Binds = axes(B,1)

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -765,19 +765,24 @@ import BandedMatrices: rowstart, rowstop, colstart, colstop,
         end
 
         @testset "band views" begin
-            for A in (rand(11,10), brand(11,10,2,3), brand(Float32, 11,10,2,3),
+            for AA in (rand(11,10), brand(11,10,2,3), brand(Float32, 11,10,2,3),
                          brand(ComplexF64, 11,10,2,3))
-                for k = -5:5
-                    V = view(A, band(k))
-                    bs = BandedMatrices.parentindices(V)[1] # a bandslice
-                    @test bs.indices == diagind(A, k)
-                    @test bs.band == Band(k)
-                    @test collect(bs) == collect(diagind(A, k))
-                    @test Vector{eltype(A)}(V) == collect(V) == A[diagind(A,k)] == A[band(k)]
-                    @test Vector{ComplexF64}(V) == Vector{ComplexF64}(A[diagind(A,k)]) ==
-                            convert(AbstractVector{ComplexF64}, V) == convert(AbstractArray{ComplexF64}, V)
-                    @test V ≡ convert(AbstractArray, V) ≡ convert(AbstractArray{eltype(A)}, V) ≡
-                            convert(AbstractArray, V) ≡ convert(AbstractVector, V)
+                for A in (AA, view(AA, 1:size(AA,1)-1, 1:size(AA,2)-2))
+                    for k = -5:5
+                        V = view(A, band(k))
+                        bs = BandedMatrices.parentindices(V)[1] # a bandslice
+                        @test bs.indices == diagind(A, k)
+                        @test bs.band == Band(k)
+                        @test collect(bs) == collect(diagind(A, k))
+                        @test Vector{eltype(A)}(V) == collect(V) == A[diagind(A,k)] == A[band(k)]
+                        @test Vector{ComplexF64}(V) == Vector{ComplexF64}(A[diagind(A,k)]) ==
+                                convert(AbstractVector{ComplexF64}, V) == convert(AbstractArray{ComplexF64}, V)
+                        @test V ≡ convert(AbstractArray, V) ≡ convert(AbstractArray{eltype(A)}, V) ≡
+                                convert(AbstractArray, V) ≡ convert(AbstractVector, V)
+
+                        V .= 0
+                        @test all(iszero, A[band(k)])
+                    end
                 end
             end
         end

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -785,6 +785,11 @@ import BandedMatrices: rowstart, rowstop, colstart, colstop,
                     end
                 end
             end
+            A = BandedMatrix(0=>1:4, 1=>5:7, -1=>8:10)
+            B = view(A, 2:4, 1:3)
+            @test B[band(0)] == A[band(-1)]
+            @test B[band(1)] == A[band(0)][2:3]
+            @test_throws BoundsError view(B, band(-1))[3]
         end
     end
 


### PR DESCRIPTION
This PR uses the fact that views of a `BandedMatrix` with `AbstractUnitRange` ranges have bands that are contiguous views of the original. This helps speed up indexing operations by forwarding these to the `bandeddata`.

On master
```julia
julia> A = brand(200, 200, 3, 4);

julia> B = view(A, 1:100, 1:100);

julia> @btime $B[band(0)];
  1.050 μs (1 allocation: 896 bytes)
```
This PR
```julia
julia> @btime $B[band(0)];
  214.281 ns (1 allocation: 896 bytes)
```