### PR TITLE
Accessor function instead of field access in checkbandmatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -165,7 +165,7 @@ function checkbandmatch(A::AbstractMatrix{T}, V::AbstractVector, k::Integer, jr:
 end
 
 function checkbandmatch(A::AbstractMatrix{T}, V::AbstractMatrix, kr::AbstractRange, jr::AbstractRange) where {T}
-    u, l = A.u, A.l
+    u, l = bandwidths(A)
     jj = 1
     for j in jr
         kk = 1

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -165,7 +165,7 @@ function checkbandmatch(A::AbstractMatrix{T}, V::AbstractVector, k::Integer, jr:
 end
 
 function checkbandmatch(A::AbstractMatrix{T}, V::AbstractMatrix, kr::AbstractRange, jr::AbstractRange) where {T}
-    u, l = bandwidths(A)
+    l, u = bandwidths(A)
     jj = 1
     for j in jr
         kk = 1


### PR DESCRIPTION
Minor change: call `bandwidths` in `checkbandmatch` instead of accessing the fields of the array. This may help in generalizing the function to other `AbstractBandedMatrix` types.