### PR TITLE
Parameterize BandSlice to accept arbitrary ranges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -456,9 +456,11 @@ julia> view(B, band(0)) isa BandedMatrices.BandedMatrixBand
 true
 ```
 """
-const BandedMatrixBand{T} = SubArray{T, 1, <:ReshapedArray{T,1,
-                                <:Union{BandedMatrix{T}, SubArray{T,2,<:BandedMatrix{T},
-                                <:NTuple{2, AbstractUnitRange{Int}}}}}, Tuple{BandSlice}}
+const BandedMatrixBand{T} = Union{
+                                SubArray{T, 1, <:ReshapedArray{T,1,
+                                    <:Union{BandedMatrix{T}, SubArray{T,2,<:BandedMatrix{T},
+                                    <:NTuple{2, AbstractUnitRange{Int}}}}}, <:Tuple{BandSlice{<:Integer}}},
+                                SubArray{T, 1, <:BandedMatrix{T}, <:Tuple{BandSlice{<:CartesianIndex{2}}}}}
 
 
 band(V::BandedMatrixBand) = first(parentindices(V)).band.i
@@ -482,11 +484,7 @@ julia> A = BandedMatrix(0=>1:4, 1=>5:7, -1=>8:10)
  ⋅  9   3  7
  ⋅  ⋅  10  4
 
-julia> v = view(A, band(1))
-3-element view(reshape(::BandedMatrix{Int64, Matrix{Int64}, Base.OneTo{Int64}}, 16), BandSlice(Band(1), 5:5:15)) with eltype Int64:
- 5
- 6
- 7
+julia> v = view(A, band(1));
 
 julia> BandedMatrices.dataview(v)
 3-element view(::Matrix{Int64}, 1, 2:4) with eltype Int64:

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -184,9 +184,9 @@ checkbandmatch(A::AbstractMatrix, V::AbstractMatrix, ::Colon, ::Colon) =
     checkbandmatch(A, V, 1:size(A,1), 1:size(A,2))
 
 """
-    BandSlice(band::Band, indices::StepRange{Int,Int}) <: OrdinalRange{Int,Int}
+    BandSlice(band::Band, indices)
 
-Represent a `StepRange` of indices corresponding to a band.
+Represent a range of indices corresponding to a band.
 
 Upon calling `to_indices`, `Band`s are converted to `BandSlice` objects to represent
 the indices over which the `Band` spans.
@@ -197,13 +197,20 @@ This mimics the relationship between `Colon` and `Base.Slice`.
 ```jldoctest
 julia> B = BandedMatrix(0 => 1:4, 1=>1:3);
 
-julia> to_indices(B, (Band(1),))[1]
-BandSlice(Band(1), 5:5:15)
+julia> bs = to_indices(B, (Band(1),))[1];
+
+julia> bs isa BandedMatrices.BandSlice
+true
+
+julia> using LinearAlgebra
+
+julia> bs == diagind(B, 1)
+true
 ```
 """
-struct BandSlice <: OrdinalRange{Int,Int}
+struct BandSlice{T, R<:AbstractRange{T}} <: AbstractRange{T}
     band::Band
-    indices::StepRange{Int,Int}
+    indices::R
 end
 
 for f in (:indices, :unsafe_indices, :axes1, :first, :last, :size, :length,
@@ -212,7 +219,7 @@ for f in (:indices, :unsafe_indices, :axes1, :first, :last, :size, :length,
 end
 
 @propagate_inbounds getindex(S::BandSlice, i::Union{Int, AbstractRange}) = getindex(S.indices, i)
-show(io::IO, r::BandSlice) = print(io, "BandSlice(", r.band, ", ", r.indices, ")")
+show(io::IO, r::BandSlice) = print(io, BandSlice, "(", r.band, ", ", r.indices, ")")
 
 to_index(::Band) = throw(ArgumentError("Block must be converted by to_indices(...)"))
 

--- a/test/test_miscs.jl
+++ b/test/test_miscs.jl
@@ -92,6 +92,11 @@ import BandedMatrices: _BandedMatrix, DefaultBandedMatrix
         B = BandedMatrix(-1=>1:4, 0=>1:5, 1=>1:4)
         Bshowstr = sprint(show, B)
         @test Bshowstr == "BandedMatrix($(-1=>[1:4;]), $(0=>[1:5;]), $(1=>[1:4;]))"
+
+        B = BandedMatrix(0=>1:3)
+        sout = sprint(show, to_indices(B, (band(0),))[1])
+        @test occursin(repr(diagind(B)), sout)
+        @test occursin(repr(Band(0)), sout)
     end
     @time @testset "Issue #27" begin
         A=brand(1,10,0,9)


### PR DESCRIPTION
On Julia v1.11, `diagind` may return a range of `CartesianIndex`es. This prepares `BandSlice` to accept such ranges.