### PR TITLE
Faster `B[:,i]` for a `BandedMatrix` using broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -418,7 +418,10 @@ end
     @boundscheck checkbounds(A, axes(A,1), j)
     r = similar(A, axes(A,1))
     r[firstindex(r):colstart(A,j)-1] .= zero(eltype(r))
-    r[colrange(A,j)] = @view A.data[data_colrange(A,j)]
+    # broadcasted assignment is currently faster than setindex
+    # see https://github.com/JuliaLang/julia/issues/40962#issuecomment-1921340377
+    # may need revisiting in the future
+    r[colrange(A,j)] .= @view A.data[data_colrange(A,j)]
     r[colstop(A,j)+1:end] .= zero(eltype(r))
     return r
 end


### PR DESCRIPTION
Currently, broadcasting is faster than `setindex!` as SIMD gets blocked in the latter  (https://github.com/JuliaLang/julia/issues/40962#issuecomment-1921340377), so this change uses the faster variant. This might need revisiting in the future if `setindex!` becomes significantly faster.

On master
```julia
julia> B = brand(6000,6000,4000,4000);

julia> @btime $B[:, 3];
  4.985 μs (4 allocations: 47.00 KiB) # master
  3.980 μs (4 allocations: 47.00 KiB) # PR

julia> @btime $B[:, 5000];
  5.619 μs (4 allocations: 47.00 KiB) # master
  4.462 μs (4 allocations: 47.00 KiB) # PR
```