### PR TITLE
Limit the number of bands printed in showing BandedMatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -968,10 +968,25 @@ end
 function show(io::IO, B::BandedMatrix)
     print(io, "BandedMatrix(")
     l, u = bandwidths(B)
-    for (ind, b) in enumerate(-l:u)
+    limit = get(io, :limit, true)
+    br = limit ? intersect(-l:u, range(-l,length=4)) : -l:u
+    for (ind, b) in enumerate(br)
         r = @view B[band(b)]
         show(io, b => r)
-        b == u || print(io, ", ")
+        b == last(br) || print(io, ", ")
+    end
+    if limit && br != -l:u
+        br2 = max(maximum(br)+1, u-3):u
+        if minimum(br2) == maximum(br)+1
+            print(io, ", ")
+        else
+            print(io, "  …  ")
+        end
+        for (ind, b) in enumerate(br2)
+            r = @view B[band(b)]
+            show(io, b => r)
+            b == u || print(io, ", ")
+        end
     end
     print(io, ")")
 end

--- a/test/test_miscs.jl
+++ b/test/test_miscs.jl
@@ -93,6 +93,13 @@ import BandedMatrices: _BandedMatrix, DefaultBandedMatrix
         Bshowstr = sprint(show, B)
         @test Bshowstr == "BandedMatrix($(-1=>[1:4;]), $(0=>[1:5;]), $(1=>[1:4;]))"
 
+        B = BandedMatrix(-3=>1:4, 3=>1:4);
+        @test sprint(show, B) == sprint(show, B, context=:limit=>true)
+        B = BandedMatrix(-5=>1:1, 5=>1:1)
+        expstr = "BandedMatrix(-5 => [1], -4 => [0, 0], -3 => [0, 0, 0], -2 => [0, 0, 0, 0]"*
+                    "  …  2 => [0, 0, 0, 0], 3 => [0, 0, 0], 4 => [0, 0], 5 => [1])"
+        @test sprint(show, B, context=:limit=>true) == expstr
+
         B = BandedMatrix(0=>1:3)
         sout = sprint(show, to_indices(B, (band(0),))[1])
         @test occursin(repr(diagind(B)), sout)


### PR DESCRIPTION
After this,
```julia
julia> B = brand(Int8,20,20,7,7);

julia> show(B)
BandedMatrix(-7 => Int8[39, -124, 64, -114, -47, 76, -40, 35, -87, 82, 40, 104, 122], -6 => Int8[49, 3, 72, -83, 84, -89, 65, 11, 3, -81, -29, -54, -80, -24], -5 => Int8[-81, -63, 127, -6, -115, 76, -120, 38, 124, 116, -14, 113, 98, -12, 47], -4 => Int8[-5, 99, -41, 40, -62, 86, -15, -90, 42, -73, -5, -24, 28, 56, 108, -91]  …  4 => Int8[13, 125, -10, -125, -96, 87, -66, 46, 127, -44, -43, 52, -70, 13, -55, -109], 5 => Int8[119, 16, 117, 122, -35, -67, -73, 89, 31, 75, -12, 101, -47, -90, 57], 6 => Int8[107, -112, -77, -57, 16, 86, -62, 52, 48, -31, -61, 26, -19, -93], 7 => Int8[0, -12, 39, 123, 90, 121, -109, 68, 57, -110, -126, -119, -93])
```
Some of the bands are not printed (indicated by `…`), which often vastly reduces the number of lines displayed. After this PR, at most 8 bands are printed.