### PR TITLE
Use MulAdd's CZeros to remove duplicate zero-fill

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.4.1"
+version = "1.5.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -17,7 +17,7 @@ BandedMatricesSparseArraysExt = "SparseArrays"
 
 [compat]
 Aqua = "0.8"
-ArrayLayouts = "1.5.3"
+ArrayLayouts = "1.6.0"
 Documenter = "1"
 FillArrays = "1.3"
 GenericLinearAlgebra = "0.3"

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -100,7 +100,7 @@ end
 @inline function materialize!(M::MatMulVecAdd{<:AbstractBandedLayout})
     checkdimensions(M)
     α,A,B,β,C = M.α,M.A,M.B,M.β,M.C
-    _fill_rmul!(C, β)
+    _fill_rmul!(M, β)
     @inbounds for j = intersect(rowsupport(A), colsupport(B))
         for k = colrange(A,j)
             C[k] += inbands_getindex(A,k,j) * B[j] * α
@@ -113,7 +113,7 @@ end
     checkdimensions(M)
     α,At,B,β,C = M.α,M.A,M.B,M.β,M.C
     A = transpose(At)
-    _fill_rmul!(C, β)
+    _fill_rmul!(M, β)
 
     @inbounds for j = rowsupport(A)
         for k = intersect(colrange(A,j), colsupport(B))
@@ -127,7 +127,7 @@ end
     checkdimensions(M)
     α,Ac,B,β,C = M.α,M.A,M.B,M.β,M.C
     A = Ac'
-    _fill_rmul!(C, β)
+    _fill_rmul!(M, β)
     @inbounds for j = rowsupport(A)
         for k = intersect(colrange(A,j), colsupport(B))
             C[j] += inbands_getindex(A,k,j)' * B[k] * α
@@ -244,7 +244,7 @@ function materialize!(M::MatMulMatAdd{<:BandedColumns, <:AbstractStridedLayout, 
     α, β, A, B, C = M.α, M.β, M.A, M.B, M.C
 
     if iszero(α)
-        rmul!(C, β)
+        _fill_rmul!(M, β)
     else
         for (colC, colB) in zip(eachcol(C), eachcol(B))
             mul!(colC, A, colB, α, β)
@@ -259,7 +259,7 @@ function materialize!(M::MatMulMatAdd{<:AbstractStridedLayout, <:BandedColumns, 
     α, β, A, B, C = M.α, M.β, M.A, M.B, M.C
 
     if iszero(α)
-        rmul!(C, β)
+        _fill_rmul!(M, β)
     else
         for (rowC, rowA) in zip(eachrow(C), eachrow(A))
             mul!(rowC, transpose(B), rowA, α, β)

--- a/src/generic/matmul.jl
+++ b/src/generic/matmul.jl
@@ -23,14 +23,14 @@ banded_gbmv!(tA, α, A, x, β, y) =
                 α, bandeddata(A), x, β, y)
 
 
-@inline function _banded_gbmv!(tA, α, A, x, β, y)
+@inline function _banded_gbmv!(tA, α, A, x, β, y, yzero=false)
     #= Some BLAS implementations throw warnings
     with zero-sized arrays, so we handle
     these cases separately.
     =#
     length(y) == 0 && return y
     if length(x) == 0
-        _fill_rmul!(y, β)
+        _fill_rmul!(y, β, yzero)
     else
         xc = Base.unalias(y, x)
         banded_gbmv!(tA, α, A, xc, β, y)
@@ -38,57 +38,57 @@ banded_gbmv!(tA, α, A, x, β, y) =
     return y
 end
 
-function _banded_muladd!(α, A, x::AbstractVector, β, y)
+function _banded_muladd!(α, A, x::AbstractVector, β, y, yzero)
     m, n = size(A)
     l, u = bandwidths(A)
     if -l > u # no bands
-        _fill_rmul!(y, β)
+        _fill_rmul!(y, β, yzero)
     elseif l < 0 # with u >= -l > 0, that is, all bands lie above the diagonal
         # E.g. (l,u) = (-1,2)
         # set lview = 0 and uview = u + l >= 0
-        _banded_gbmv!('N', α, view(A, :, 1-l:n), view(x, 1-l:n), β, y)
+        _banded_gbmv!('N', α, view(A, :, 1-l:n), view(x, 1-l:n), β, y, yzero)
     elseif u < 0 # with -l <= u < 0, that is, all bands lie below the diagnoal.
         # E.g. (l,u) = (2,-1)
         # set lview = l + u >= 0 and uview = 0
-        _fill_rmul!(@view(y[1:-u]), β)
-        _banded_gbmv!('N', α, view(A, 1-u:m, :), x, β, view(y, 1-u:m))
+        _fill_rmul!(@view(y[1:-u]), β, yzero)
+        _banded_gbmv!('N', α, view(A, 1-u:m, :), x, β, view(y, 1-u:m), yzero)
         y
     else
-        _banded_gbmv!('N', α, A, x, β, y)
+        _banded_gbmv!('N', α, A, x, β, y, yzero)
     end
 end
 
 function materialize!(M::BlasMatMulVecAdd{<:BandedColumnMajor,<:AbstractStridedLayout,<:AbstractStridedLayout,<:BlasFloat})
     checkdimensions(M)
-    _banded_muladd!(M.α, M.A, M.B, M.β, M.C)
+    _banded_muladd!(M.α, M.A, M.B, M.β, M.C, M.Czero)
 end
 
-function _banded_muladd_row!(tA, α, At, x, β, y)
+function _banded_muladd_row!(tA, α, At, x, β, y, yzero=false)
     n, m = size(At)
     u, l = bandwidths(At)
     if -l > u # no bands
-        _fill_rmul!(y, β)
+        _fill_rmul!(y, β, yzero)
     elseif l < 0
-        _banded_gbmv!(tA, α, view(At, 1-l:n, :,), view(x, 1-l:n), β, y)
+        _banded_gbmv!(tA, α, view(At, 1-l:n, :,), view(x, 1-l:n), β, y, yzero)
     elseif u < 0
-        _fill_rmul!(@view(y[1:-u]), β)
-        _banded_gbmv!(tA, α, view(At, :, 1-u:m), x, β, view(y, 1-u:m))
+        _fill_rmul!(@view(y[1:-u]), β, yzero)
+        _banded_gbmv!(tA, α, view(At, :, 1-u:m), x, β, view(y, 1-u:m), yzero)
         y
     else
-        _banded_gbmv!(tA, α, At, x, β, y)
+        _banded_gbmv!(tA, α, At, x, β, y, yzero)
     end
 end
 
 function materialize!(M::BlasMatMulVecAdd{<:BandedRowMajor,<:AbstractStridedLayout,<:AbstractStridedLayout,<:BlasFloat})
     checkdimensions(M)
-    α, A, x, β, y = M.α, M.A, M.B, M.β, M.C
-    _banded_muladd_row!('T', α, transpose(A), x, β, y)
+    α, A, x, β, y, yzero = M.α, M.A, M.B, M.β, M.C, M.Czero
+    _banded_muladd_row!('T', α, transpose(A), x, β, y, yzero)
 end
 
 function materialize!(M::BlasMatMulVecAdd{<:ConjLayout{<:BandedRowMajor},<:AbstractStridedLayout,<:AbstractStridedLayout,<:BlasComplex})
     checkdimensions(M)
-    α, A, x, β, y = M.α, M.A, M.B, M.β, M.C
-    _banded_muladd_row!('C', α, A', x, β, y)
+    α, A, x, β, y, yzero = M.α, M.A, M.B, M.β, M.C, M.Czero
+    _banded_muladd_row!('C', α, A', x, β, y, yzero)
 end
 
 
@@ -174,17 +174,18 @@ end
 const ConjOrBandedLayout = Union{AbstractBandedLayout,ConjLayout{<:AbstractBandedLayout}}
 const ConjOrBandedColumnMajor = Union{<:BandedColumnMajor,ConjLayout{<:BandedColumnMajor}}
 
-function _banded_muladd!(α::T, A, B::AbstractMatrix, β, C) where T
-    gbmm!('N', 'N', α, A, B, β, C)
+function _banded_muladd!(α::T, A, B::AbstractMatrix, β, C, Czero=false) where T
+    gbmm!('N', 'N', α, A, B, β, C, Czero)
     C
 end
 
 materialize!(M::BlasMatMulMatAdd{<:AbstractBandedLayout,<:AbstractBandedLayout,<:BandedColumnMajor}) =
-    materialize!(MulAdd(M.α, convert(DefaultBandedMatrix,M.A), convert(DefaultBandedMatrix,M.B), M.β, M.C))
+    materialize!(MulAdd(M.α, convert(DefaultBandedMatrix,M.A), convert(DefaultBandedMatrix,M.B),
+        M.β, M.C; Czero = M.Czero))
 
 function materialize!(M::BlasMatMulMatAdd{<:BandedColumnMajor,<:BandedColumnMajor,<:BandedColumnMajor})
     checkdimensions(M)
-    _banded_muladd!(M.α, M.A, M.B, M.β, M.C)
+    _banded_muladd!(M.α, M.A, M.B, M.β, M.C, M.Czero)
 end
 
 

--- a/src/generic/utils.jl
+++ b/src/generic/utils.jl
@@ -28,3 +28,4 @@ end
 
 _fill_lmul!(β, A::AbstractArray{T}) where T = iszero(β) ? zero!(A) : lmul!(β, A)
 _fill_rmul!(A::AbstractArray{T}, β) where T = iszero(β) ? zero!(A) : rmul!(A, β)
+_fill_rmul!(M::MulAdd, β) = iszero(β) ? (M.Czero ? M.C : zero!(M.C)) : rmul!(M.C, β)

--- a/src/generic/utils.jl
+++ b/src/generic/utils.jl
@@ -26,6 +26,6 @@ function sumbandwidths(A::AbstractMatrix, B::AbstractMatrix)
 end
 
 
-_fill_lmul!(β, A::AbstractArray{T}) where T = iszero(β) ? zero!(A) : lmul!(β, A)
-_fill_rmul!(A::AbstractArray{T}, β) where T = iszero(β) ? zero!(A) : rmul!(A, β)
-_fill_rmul!(M::MulAdd, β) = iszero(β) ? (M.Czero ? M.C : zero!(M.C)) : rmul!(M.C, β)
+_fill_lmul!(β, A::AbstractArray, Azero=false) = iszero(β) ? (Azero ? A : zero!(A)) : lmul!(β, A)
+_fill_rmul!(A::AbstractArray, β, Azero=false) = iszero(β) ? (Azero ? A : zero!(A)) : rmul!(A, β)
+_fill_rmul!(M::MulAdd, β) = _fill_rmul!(M.C, β, M.Czero)


### PR DESCRIPTION
With this, multiplying a `BandedMatrix` by a `OneElementVector`  would be as performant as slicing.
```julia
julia> B = brand(6000,6000,4000,4000); O = OneElement(1, 3, size(B,2));

julia> @btime $B * $O;
  3.826 μs (2 allocations: 46.92 KiB)

julia> @btime $B[:,$O.ind...];
  4.013 μs (4 allocations: 47.00 KiB)
```