### PR TITLE
`parent(::BandedMatrix)` returns the underlying data

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -970,10 +970,25 @@ end
 function show(io::IO, B::BandedMatrix)
     print(io, "BandedMatrix(")
     l, u = bandwidths(B)
-    for (ind, b) in enumerate(-l:u)
+    limit = get(io, :limit, true)
+    br = limit ? intersect(-l:u, range(-l,length=4)) : -l:u
+    for (ind, b) in enumerate(br)
         r = @view B[band(b)]
         show(io, b => r)
-        b == u || print(io, ", ")
+        b == last(br) || print(io, ", ")
+    end
+    if limit && br != -l:u
+        br2 = max(maximum(br)+1, u-3):u
+        if minimum(br2) == maximum(br)+1
+            print(io, ", ")
+        else
+            print(io, "  …  ")
+        end
+        for (ind, b) in enumerate(br2)
+            r = @view B[band(b)]
+            show(io, b => r)
+            b == u || print(io, ", ")
+        end
     end
     print(io, ")")
 end

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -29,6 +29,8 @@ end
 
 _BandedMatrix(data::AbstractMatrix, m::Integer, l, u) = _BandedMatrix(data, oneto(m), l, u)
 
+Base.parent(B::BandedMatrix) = B.data
+
 const DefaultBandedMatrix{T} = BandedMatrix{T,Matrix{T},OneTo{Int}}
 
 bandedcolumns(_) = BandedColumns{UnknownLayout}()
@@ -968,25 +970,10 @@ end
 function show(io::IO, B::BandedMatrix)
     print(io, "BandedMatrix(")
     l, u = bandwidths(B)
-    limit = get(io, :limit, true)
-    br = limit ? intersect(-l:u, range(-l,length=4)) : -l:u
-    for (ind, b) in enumerate(br)
+    for (ind, b) in enumerate(-l:u)
         r = @view B[band(b)]
         show(io, b => r)
-        b == last(br) || print(io, ", ")
-    end
-    if limit && br != -l:u
-        br2 = max(maximum(br)+1, u-3):u
-        if minimum(br2) == maximum(br)+1
-            print(io, ", ")
-        else
-            print(io, "  …  ")
-        end
-        for (ind, b) in enumerate(br2)
-            r = @view B[band(b)]
-            show(io, b => r)
-            b == u || print(io, ", ")
-        end
+        b == u || print(io, ", ")
     end
     print(io, ")")
 end

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -66,6 +66,12 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
         @test BandedMatrix{Int64, typeof(matrix)}(matrix, (1, 1)).data isa typeof(matrix)
         @test_throws UndefRefError BandedMatrix{Vector{Float64}}(undef, (5,5), (1,1))[1,1]
 
+        @testset "parent" begin
+            A = zeros(3,5)
+            B = _BandedMatrix(A, 5, 1, 1)
+            @test parent(B) === A
+        end
+
         @testset "Construction from Diagonal" begin
             D = Diagonal(1:4)
             B1 = BandedMatrix(D)


### PR DESCRIPTION
This will conform to the commonly used meaning of `parent` for arrays.