### PR TITLE
Fix indexing for offset views of BandedMatrixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/generic/AbstractBandedMatrix.jl
+++ b/src/generic/AbstractBandedMatrix.jl
@@ -60,7 +60,7 @@ julia> BandedMatrices.colstart(A, 4)
 3
 ```
 """
-@inline colstart(A, i::Integer) = max(i-bandwidth(A,2), 1)
+@inline colstart(A, i::Integer) = max(i-bandwidth(A,2), 0) + firstindex(A,1)-1
 
 """
     colstop(A, i::Integer)
@@ -84,7 +84,7 @@ julia> BandedMatrices.colstop(A, 4)
 4
 ```
 """
-@inline  colstop(A, i::Integer) = max(min(i+bandwidth(A,1), size(A, 1)), 0)
+@inline colstop(A, i::Integer) = clamp(i+bandwidth(A,1), 0:size(A, 1)) + firstindex(A,1)-1
 
 """
     rowstart(A, i::Integer)
@@ -108,7 +108,7 @@ julia> BandedMatrices.rowstart(A, 3)
 3
 ```
 """
-@inline rowstart(A, i::Integer) = max(i-bandwidth(A,1), 1)
+@inline rowstart(A, i::Integer) = max(i-bandwidth(A,1), 1) + firstindex(A,2)-1
 
 """
     rowstop(A, i::Integer)
@@ -132,7 +132,7 @@ julia> BandedMatrices.rowstop(A, 4)
 4
 ```
 """
-@inline  rowstop(A, i::Integer) = max(min(i+bandwidth(A,2), size(A, 2)), 0)
+@inline rowstop(A, i::Integer) = clamp(i+bandwidth(A,2), 0:size(A, 2)) + firstindex(A,2)-1
 
 """
     colrange(A, i::Integer)

--- a/src/generic/AbstractBandedMatrix.jl
+++ b/src/generic/AbstractBandedMatrix.jl
@@ -60,7 +60,7 @@ julia> BandedMatrices.colstart(A, 4)
 3
 ```
 """
-@inline colstart(A, i::Integer) = max(i-bandwidth(A,2), 0) + firstindex(A,1)-1
+@inline colstart(A, i::Integer) = max(i-bandwidth(A,2), 1) + firstindex(A,1)-1
 
 """
     colstop(A, i::Integer)

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -556,4 +556,13 @@ Base.similar(::MyMatrix, ::Type{T}, m::Int, n::Int) where T = MyMatrix{T}(undef,
         copyto!(view(B, :, :), S)
         @test B == 2B2
     end
+
+    @testset "offset views" begin
+        B = BandedMatrix(0=>1:4)
+        A = view(B, Base.IdentityUnitRange(2:4), 1:4)
+        @test !any(in(axes(A,1)), BandedMatrices.colrange(A, 1))
+        @test BandedMatrices.colrange(A, 2) == 2:2
+        @test BandedMatrices.colrange(A, 3) == 3:3
+        @test BandedMatrices.colrange(A, 4) == 4:4
+    end
 end


### PR DESCRIPTION
On master
```julia
julia> B = BandedMatrix(0=>1:4)
4×4 BandedMatrix{Int64} with bandwidths (0, 0):
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> view(B, Base.IdentityUnitRange(2:4), 1:4)
3×4 view(::BandedMatrix{Int64, Matrix{Int64}, Base.OneTo{Int64}}, Base.IdentityUnitRange(2:4), 1:4) with eltype Int64 with indices 2:4×Base.OneTo(4):
 ⋅  ⋅  0  ⋅
 ⋅  ⋅  ⋅  0
 ⋅  ⋅  ⋅  ⋅
```
This PR
```julia
julia> view(B, Base.IdentityUnitRange(2:4), 1:4)
3×4 view(::BandedMatrix{Int64, Matrix{Int64}, Base.OneTo{Int64}}, Base.IdentityUnitRange(2:4), 1:4) with eltype Int64 with indices 2:4×Base.OneTo(4):
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4
```