### PR TITLE
Docstring for `lu!`

### DIFF
--- a/src/banded/BandedLU.jl
+++ b/src/banded/BandedLU.jl
@@ -79,6 +79,17 @@ Matrix(F::BandedLU) = Array(AbstractArray(F))
 Array(F::BandedLU) = Matrix(F)
 
 ##
+"""
+    lu!(A::BandedMatrix, pivot = Val(true); check = true)
+
+Compute the LU factorization of a banded matrix `A` inplace, overwriting the matrix.
+This factorization requires `A` to have extra storage, and in particular if the banded
+matrix of interest has bandwidths `(l, u)` then `A` should have bandwidths `(l, l+u)`
+and contain the desired matrix along with zeros in the additional entries.
+
+When `check = true`, an error is thrown if the factorization fails. When `check = false`
+it is the user's responsibility for checking the validity of the factorization.
+"""
 function lu!(A::BandedMatrix{T}, pivot::Union{Val{false}, Val{true}} = Val(true);
              check::Bool = true) where T<:BlasFloat
     if pivot === Val(false)


### PR DESCRIPTION
Hi, this pr is to add a docstring to `lu!` for banded matrices to warn the user about the need for additional storage in the matrix, as discussed in #197.