### PR TITLE
data_rowrange bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.7.3"
+version = "1.7.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -573,7 +573,7 @@ data_colrange(A::BandedMatrix{T}, i::Integer) where {T} =
 
 function data_rowrange(A::BandedMatrix, rowind::Integer)
     range(rowind ≤ 1+A.l ? A.u+rowind : (rowind-A.l)*size(A.data,1),
-        step = size(A.data,1)-1,
+        step = max(size(A.data,1)-1, 1),
         length = length(rowrange(A,rowind)),
     )
 end

--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -572,9 +572,9 @@ data_colrange(A::BandedMatrix{T}, i::Integer) where {T} =
                                 ((i-1)*size(A.data,1))
 
 function data_rowrange(A::BandedMatrix, rowind::Integer)
-    range(rowind ≤ 1+A.l ? A.u+rowind : (rowind-A.l)*size(A.data,1),
-        step = max(size(A.data,1)-1, 1),
-        length = length(rowrange(A,rowind)),
+    StepRangeLen(rowind ≤ 1+A.l ? A.u+rowind : (rowind-A.l)*size(A.data,1),
+        size(A.data,1)-1,
+        length(rowrange(A,rowind))
     )
 end
 

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -346,6 +346,12 @@ import BandedMatrices: rowstart, rowstop, colstart, colstop,
             @test_throws BoundsError a[0, BandRange] = [1, 2, 3]
             @test_throws BoundsError a[9, BandRange] = [1, 2, 3]
             @test_throws DimensionMismatch a[1, BandRange] = [1, 2]
+
+            a = BandedMatrix(ones(2, 5), (-2, 2))
+            # 0.0 0.0 1.0 0.0 0.0
+            # 0.0 0.0 0.0 1.0 0.0
+            @test a[1,:] == [0, 0, 1, 0, 0]
+            @test a[2,:] == [0, 0, 0, 1, 0]
         end
 
 


### PR DESCRIPTION
I found a bug with indexing rows of a BandedMatrix whose data matrix is one row:

```
julia> a = BandedMatrix(ones(2,5), (0,0))
2×5 BandedMatrix{Float64} with bandwidths (0, 0):
 1.0   ⋅    ⋅    ⋅    ⋅
  ⋅   1.0   ⋅    ⋅    ⋅

julia> a[1,:]
ERROR: ArgumentError: step cannot be zero
Stacktrace:
 [1] steprange_last
   @ .\range.jl:338 [inlined]
 [2] StepRange
   @ .\range.jl:325 [inlined]
 [3] range_start_step_length(a::Int64, step::Int64, len::Int64)
   @ Base .\range.jl:216
 [4] _range
   @ .\range.jl:168 [inlined]
 [5] range
   @ .\range.jl:147 [inlined]
 [6] data_rowrange
   @ d:\Documents\Github\BandedMatrices.jl\src\banded\BandedMatrix.jl:575 [inlined]
 [7] getindex(A::BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, k::Int64, ::Colon)
   @ BandedMatrices d:\Documents\Github\BandedMatrices.jl\src\banded\BandedMatrix.jl:443
 [8] top-level scope
   @ REPL[23]:1
```

I added a fix and unit tests to go with it.