### PR TITLE
Focus development on julia v1.10+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.7.6"
+version = "1.8.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -22,13 +22,13 @@ Documenter = "1"
 FillArrays = "1.3"
 GenericLinearAlgebra = "0.3"
 InfiniteArrays = "0.12, 0.13, 0.14"
-LinearAlgebra = "1.6"
+LinearAlgebra = "1"
 PrecompileTools = "1"
 Quaternions = "0.7"
-Random = "1.6"
-SparseArrays = "1.6"
-Test = "1.6"
-julia = "1.6"
+Random = "1"
+SparseArrays = "1"
+Test = "1"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -92,10 +92,6 @@ include("tribanded.jl")
 
 include("interfaceimpl.jl")
 
-if !isdefined(Base, :get_extension)
-    include("../ext/BandedMatricesSparseArraysExt.jl")
-end
-
 include("precompile.jl")
 
 


### PR DESCRIPTION
Since this is the LTS now, we don't need to explicitly support v1.6 anymore. Versions of this package <v1.8 would continue to be compatible with julia v1.6.