### PR TITLE
Define `dataids` for a `BandedMatrix`

### DIFF
--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -30,6 +30,7 @@ end
 _BandedMatrix(data::AbstractMatrix, m::Integer, l, u) = _BandedMatrix(data, oneto(m), l, u)
 
 Base.parent(B::BandedMatrix) = B.data
+Base.dataids(B::BandedMatrix) = (Base.dataids(B.data)..., Base.dataids(B.raxis)...)
 
 const DefaultBandedMatrix{T} = BandedMatrix{T,Matrix{T},OneTo{Int}}
 


### PR DESCRIPTION
Profiling shows that this saves some time in matrix-vector multiplications.
```julia
julia> B = brand(100, 100, 0, 0);

julia> v = rand(size(B,2));

julia> w = similar(v, size(B,1));

julia> @btime mul!($w, $B, $v);
  763.242 ns (0 allocations: 0 bytes) # master
  698.709 ns (0 allocations: 0 bytes) # This PR
```