### PR TITLE
Specialize `unaliascopy` for a `BandedMatrix`

### DIFF
--- a/src/banded/BandedMatrix.jl
+++ b/src/banded/BandedMatrix.jl
@@ -1032,3 +1032,7 @@ function one(A::BandedMatrix)
     m==n || throw(DimensionMismatch("multiplicative identity defined only for square matrices"))
     typeof(A)(I, (m,n))
 end
+
+function Base.unaliascopy(B::BandedMatrix)
+    _BandedMatrix(Base.unaliascopy(B.data), Base.unaliascopy(B.raxis), B.l, B.u)
+end

--- a/test/test_banded.jl
+++ b/test/test_banded.jl
@@ -586,6 +586,13 @@ include("mymatrix.jl")
         @test Q == I(5)
         @test eltype(Q) == Float64
     end
+
+    @testset "unaliascopy" begin
+        B = BandedMatrices._BandedMatrix(view(randn(1, 5),:,:), 5, 0, 0)
+        B2 = Base.unaliascopy(B)
+        @test B2 == B
+        @test typeof(B2) == typeof(B)
+    end
 end
 
 end # module


### PR DESCRIPTION
This might help with certain unaliasing operations, as `unaliascopy` requires the type of the matrix to be preserved.