### PR TITLE
Avoid pirating `qr` by shadowing the function

### DIFF
--- a/src/BandedMatrices.jl
+++ b/src/BandedMatrices.jl
@@ -16,7 +16,7 @@ import Base: rot180
 
 import LinearAlgebra: _apply_inverse_ipiv_rows!, _apply_ipiv_rows!, _chol!, axpy!, cholcopy, diag, diagzero, dot, eigen,
                       eigen!, eigvals, eigvals!, factorize, isdiag, istril, istriu, ldiv!, ldlt, ldlt!, lmul!,
-                      logabsdet, lu, lu!, mul!, qr, qr!, rmul!, svdvals, svdvals!, tril!, triu!
+                      logabsdet, lu, lu!, mul!, rmul!, svdvals, svdvals!, tril!, triu!
 
 using LinearAlgebra: AbstractTriangular, AdjOrTrans, BlasComplex, BlasFloat, BlasInt, BlasReal, Givens, HermOrSym,
                      QRPackedQ, RealHermSymComplexHerm, StructuredMatrixStyle, checksquare, chkstride1, ipiv2perm, AdjointQ

--- a/src/banded/bandedqr.jl
+++ b/src/banded/bandedqr.jl
@@ -2,6 +2,7 @@ _qr(::AbstractBandedLayout, ax, A) = _banded_qr(ax, A)
 _banded_qr(_, A) = qr!(BandedMatrix{float(eltype(A))}(A, (bandwidth(A,1),bandwidth(A,1)+bandwidth(A,2))))
 
 qr(A::Tridiagonal{T}) where T = qr!(BandedMatrix{float(T)}(A, (1,2)))
+qr(args...; kwargs...) = LinearAlgebra.qr(args...; kwargs...)
 _qr!(::AbstractBandedLayout, _, A) = banded_qr!(A)
 
 

--- a/src/banded/linalg.jl
+++ b/src/banded/linalg.jl
@@ -72,4 +72,4 @@ end
 \(A::AdjointFact{<:Any,<:BandedLU}, B::Adjoint{<:Any,<:AbstractVecOrMat}) = A \ copy(B)
 \(A::TransposeFact{<:Any,<:BandedLU}, B::Transpose{<:Any,<:AbstractVecOrMat}) = A \ copy(B)
 
-_factorize(::AbstractBandedLayout, _, A) = size(A,1) == size(A,2) ? lu(A) : LinearAlgebra.qr(A)
+_factorize(::AbstractBandedLayout, _, A) = size(A,1) == size(A,2) ? lu(A) : qr(A)

--- a/src/banded/linalg.jl
+++ b/src/banded/linalg.jl
@@ -72,4 +72,4 @@ end
 \(A::AdjointFact{<:Any,<:BandedLU}, B::Adjoint{<:Any,<:AbstractVecOrMat}) = A \ copy(B)
 \(A::TransposeFact{<:Any,<:BandedLU}, B::Transpose{<:Any,<:AbstractVecOrMat}) = A \ copy(B)
 
-_factorize(::AbstractBandedLayout, _, A) = size(A,1) == size(A,2) ? lu(A) : qr(A)
+_factorize(::AbstractBandedLayout, _, A) = size(A,1) == size(A,2) ? lu(A) : LinearAlgebra.qr(A)

--- a/test/test_bandedqr.jl
+++ b/test/test_bandedqr.jl
@@ -58,14 +58,14 @@ Random.seed!(0)
         @test_broken qr(A)\b ≈ Matrix(A)\b
 
         A = Tridiagonal(randn(T,99), randn(T,100), randn(T,99))
-        @test qr(A).factors ≈ LinearAlgebra.qrfactUnblocked!(Matrix(A)).factors
-        @test qr(A).τ ≈ LinearAlgebra.qrfactUnblocked!(Matrix(A)).τ
+        @test BandedMatrices.qr(A).factors ≈ LinearAlgebra.qrfactUnblocked!(Matrix(A)).factors
+        @test BandedMatrices.qr(A).τ ≈ LinearAlgebra.qrfactUnblocked!(Matrix(A)).τ
         b=rand(T,100)
-        @test qr(A)\b ≈ Matrix(A)\b
+        @test BandedMatrices.qr(A)\b ≈ Matrix(A)\b
         b=rand(T,100,2)
-        @test qr(A)\b ≈ Matrix(A)\b
-        @test_throws DimensionMismatch qr(A) \ randn(3)
-        @test_throws DimensionMismatch qr(A).Q'randn(3)
+        @test BandedMatrices.qr(A)\b ≈ Matrix(A)\b
+        @test_throws DimensionMismatch BandedMatrices.qr(A) \ randn(3)
+        @test_throws DimensionMismatch BandedMatrices.qr(A).Q'randn(3)
     end
 
     @testset "Mixed types" begin


### PR DESCRIPTION
This creates a `BandedMatrices.qr` that is distinct from `LinearAlgebra.qr`.