### PR TITLE
docs: document Band and BandError

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BandedMatrices"
 uuid = "aae01518-5342-5314-be14-df237901396f"
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -99,6 +99,14 @@ band
 ```
 
 ```@docs
+Band
+```
+
+```@docs
+BandError
+```
+
+```@docs
 BandRange
 ```
 

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -1,4 +1,30 @@
-# ~~ Type to set\get data along a band
+"""
+    Band(i)
+
+Index selector for the diagonal at offset `i` of a banded matrix. `Band(0)` selects the
+main diagonal, positive offsets select superdiagonals, and negative offsets select
+subdiagonals.
+
+# Fields
+
+- `i::Int`: Diagonal offset from the main diagonal.
+
+# Arguments
+
+- `i::Integer`: Diagonal offset to select.
+
+# Examples
+
+```jldoctest
+julia> A = BandedMatrix(0 => 1:3, 1 => 4:5);
+
+julia> A[Band(0)] == [1, 2, 3]
+true
+
+julia> A[Band(1)] == [4, 5]
+true
+```
+"""
 struct Band
     i::Int
 end
@@ -71,7 +97,32 @@ const BandRange = BandRangeType()
 to_indices(A::AbstractArray, (_, j)::Tuple{BandRangeType,Integer}) = (colrange(A, j), j)
 to_indices(A::AbstractArray, (k, _)::Tuple{Integer,BandRangeType}) = (k, rowrange(A, k))
 
-# ~~ Out of band error
+"""
+    BandError(A, i)
+
+Exception thrown when an operation accesses diagonal offset `i` outside the stored lower
+and upper bandwidths of `A`.
+
+# Fields
+
+- `A::AbstractMatrix`: Matrix whose band structure rejects the access.
+- `i::Int`: Requested diagonal offset, with positive offsets above and negative offsets
+  below the main diagonal.
+
+# Arguments
+
+- `A::AbstractMatrix`: Matrix whose band structure is being accessed.
+- `i::Integer`: Requested diagonal offset.
+
+# Examples
+
+```jldoctest
+julia> A = BandedMatrix(0 => 1:3);
+
+julia> BandError(A, 1) isa BandError
+true
+```
+"""
 struct BandError <: Exception
     A::AbstractMatrix
     i::Int

--- a/src/generic/Band.jl
+++ b/src/generic/Band.jl
@@ -11,7 +11,7 @@ subdiagonals.
 
 # Arguments
 
-- `i::Integer`: Diagonal offset to select.
+- `i::Int`: Diagonal offset to select.
 
 # Examples
 
@@ -99,6 +99,8 @@ to_indices(A::AbstractArray, (k, _)::Tuple{Integer,BandRangeType}) = (k, rowrang
 
 """
     BandError(A, i)
+    BandError(A, (k, j))
+    BandError(A)
 
 Exception thrown when an operation accesses diagonal offset `i` outside the stored lower
 and upper bandwidths of `A`.
@@ -112,7 +114,9 @@ and upper bandwidths of `A`.
 # Arguments
 
 - `A::AbstractMatrix`: Matrix whose band structure is being accessed.
-- `i::Integer`: Requested diagonal offset.
+- `i::Int`: Requested diagonal offset.
+- `(k, j)::Tuple{Int, Int}`: Matrix coordinates from which the diagonal offset `j - k` is
+  computed.
 
 # Examples
 


### PR DESCRIPTION
## Summary

Documents `Band` and `BandError` at their source definitions, including fields, arguments, and executable examples. Adds both names to the existing rendered API page.

This is the upstream dependency for FastAlmostBandedMatrices.jl removing its local public-doc QA suppression.

Ignore until reviewed by @ChrisRackauckas.

## Verification

- `julia --project -e 'using Pkg; Pkg.test()'`\n  - `Overall | 30727 passed, 5 broken, 30732 total`\n- `julia --project=docs docs/make.jl`\n  - Doctest, document checks, and HTML rendering completed. The existing build emitted six `:missing_docs` warnings under its pre-existing `warnonly` configuration.\n- `typos --format brief src/generic/Band.jl docs/src/index.md`\n- `git diff --check`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791